### PR TITLE
ci: Add workflow for changed files

### DIFF
--- a/.github/workflows/changed-files-and-dirs.yaml
+++ b/.github/workflows/changed-files-and-dirs.yaml
@@ -37,10 +37,12 @@ jobs:
             echo "$file was changed"
           done
 
-      #Find the directory where files have been changed.
+      #*Find the directory where files have been changed.
       - name: Get changed directories
         id: changed-dir
         uses: tj-actions/changed-files@v35
+        #*Step fails if nothing found.
+        continue-on-error: true #*Allows workflow to proceed if no files found
         with:
           files: |
             **/*${{ inputs.file-type }}
@@ -48,5 +50,6 @@ jobs:
           dir_names_exclude_root: true
 
       - name: List output directories
+        if: ${{ steps.changed-dir.conclusion == 'success'}}
         run: |
           echo "${{ steps.changed-dir.outputs.all_changed_files }}"

--- a/.github/workflows/changed-files-and-dirs.yaml
+++ b/.github/workflows/changed-files-and-dirs.yaml
@@ -1,4 +1,4 @@
-name: Change files and directories
+name: Changed files and directories
 on:
   pull_request:
     types:
@@ -50,7 +50,7 @@ jobs:
         uses: tj-actions/changed-files@v35
         with:
           files: |
-            **/*.${{ inputs.file-type }}
+            **/*${{ inputs.file-type }}
           dir_names: true
           dir_names_exclude_root: true
 

--- a/.github/workflows/changed-files-and-dirs.yaml
+++ b/.github/workflows/changed-files-and-dirs.yaml
@@ -1,15 +1,5 @@
 name: Changed files and directories
 on:
-#TODO: remove PR trigger
-#? are more inputs required for branches to compare
-#? Whats the error from the last run all about
-  pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
-    branches:
-      - main
   workflow_call:
     inputs:
       file-type:

--- a/.github/workflows/changed-files-and-dirs.yaml
+++ b/.github/workflows/changed-files-and-dirs.yaml
@@ -1,5 +1,8 @@
 name: Changed files and directories
 on:
+#TODO: remove PR trigger
+#? are more inputs required for branches to compare
+#? Whats the error from the last run all about
   pull_request:
     types:
       - opened

--- a/.github/workflows/changed-files-and-dirs.yaml
+++ b/.github/workflows/changed-files-and-dirs.yaml
@@ -1,0 +1,59 @@
+name: Change files and directories
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+    branches:
+      - main
+  workflow_call:
+    inputs:
+      file-type:
+        description: "The type of file to search for"
+        required: true
+        type: string
+    outputs:
+      changed-files:
+        description: "The names of files that have been updated"
+        value: ${{ jobs.changes.outputs.files }}
+      dir-names:
+        description: "The names of the directories that contain changed files"
+        value: ${{ jobs.changes.outputs.dirs }}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.changed-files.outputs.all_changed_files }}
+      dirs: ${{ steps.changed-dir.outputs.all_changed_files }}
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+
+      - name: List all changed files
+        run: |
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "$file was changed"
+          done
+
+      #Find the directory where files have been changed.
+      - name: Get changed directories
+        id: changed-dir
+        uses: tj-actions/changed-files@v35
+        with:
+          files: |
+            **/*.${{ inputs.file-type }}
+          dir_names: true
+          dir_names_exclude_root: true
+
+      - name: List output directories
+        run: |
+          echo "${{ steps.changed-dir.outputs.all_changed_files }}"

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -19,17 +19,9 @@ permissions:
 
 jobs:
   find-terraform:
-    runs-on: ubuntu-latest
-    outputs:
-      files: ${{ steps.find-tf-dir.outputs.files }}
-      dir: ${{ steps.find-tf-dir.outputs.dirs }}
-
-    steps:
-      - name: Search for terraform files
-        id: find-tf-dir
-        uses: ./.github/workflows/changed-files-and-dirs.yaml
-        with:
-          file-type: '.tf'
+    uses: ./.github/workflows/changed-files-and-dirs.yaml
+    with:
+      file-type: '.tf'
 
   lint:
     runs-on: ubuntu-latest
@@ -39,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Terraform
-        if: contains(needs.find-terraform.outputs.files, '.tf')
+        if: contains(needs.find-terraform.outputs.changed-files, '.tf')
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ inputs.terraform-version }}
@@ -47,8 +39,8 @@ jobs:
 
       #Initialise terraform in the directory where terraform file have changed.
       - name: Initialise Terraform
-        if: contains(needs.find-terraform.outputs.files, '.tf')
-        working-directory: ${{ needs.find-terraform.outputs.dir }}
+        if: contains(needs.find-terraform.outputs.changed-files, '.tf')
+        working-directory: ${{ needs.find-terraform.outputs.dir-names }}
         run: terraform init
 
       - name: Lint with trunk

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -26,6 +26,8 @@ jobs:
       - name: Search for terraform files
         id: find-terraform
         uses: ./.github/workflows/changed-files-and-dirs.yaml
+        with:
+          file-type: '.tf'
 
       - name: Setup Terraform
         if: contains(steps.find-terraform.outputs.changed-files, '.tf')

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -35,6 +35,8 @@ jobs:
         uses: tj-actions/changed-files@v35
         with:
           dir_names: true
+
+      - name: List output directories
         run: |
           echo "${{ steps.changed-files.outputs.all_changed_files }}"
 

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -34,11 +34,14 @@ jobs:
         id: terraform-dir
         uses: tj-actions/changed-files@v35
         with:
+          files: |
+            **/*.tf
           dir_names: true
+          dir_names_exclude_root: true
 
       - name: List output directories
         run: |
-          echo "${{ steps.changed-files.outputs.all_changed_files }}"
+          echo "${{ steps.terraform-dir.outputs.all_changed_files }}"
 
       - name: Setup Terraform
         if: contains(steps.changed-files.outputs.all_changed_files, '.tf')

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -21,7 +21,7 @@ jobs:
   find-terraform:
     uses: ./.github/workflows/changed-files-and-dirs.yaml
     with:
-      file-type: '.tf'
+      file-type: ".tf"
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -29,6 +29,15 @@ jobs:
             echo "$file was changed"
           done
 
+      - name: Output terraform working directory
+        if: contains(steps.changed-files.outputs.all_changed_files, '.tf')
+        id: terraform-dir
+        uses: tj-actions/changed-files@v35
+        with:
+          dir_names: true
+        run: |
+          echo "${{ steps.changed-files.outputs.all_changed_files }}"
+
       - name: Setup Terraform
         if: contains(steps.changed-files.outputs.all_changed_files, '.tf')
         uses: hashicorp/setup-terraform@v2
@@ -38,7 +47,7 @@ jobs:
 
       - name: Initialise Terraform
         if: contains(steps.changed-files.outputs.all_changed_files, '.tf')
-        working-directory: ./terraform
+        working-directory: ${{ steps.terraform-dir.outputs.all_changed_files }}
         run: terraform init
 
       - name: Lint with trunk

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -1,5 +1,10 @@
 name: Lint and test
 on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
   workflow_call:
 
 jobs:

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -1,5 +1,5 @@
 name: Lint and test
-on: 
+on:
   workflow_call:
 
 jobs:
@@ -11,6 +11,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+
+      - name: List all changed files
+        run: |
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "$file was changed"
+          done
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -1,10 +1,12 @@
 name: Lint and test
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
       - synchronize
+    branches:
+      - main
   workflow_call:
 
 jobs:
@@ -28,14 +30,17 @@ jobs:
           done
 
       - name: Setup Terraform
+        if: contains(steps.changed-files.outputs.all_changed_files, '.tf')
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.3
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Initialise Terraform
+        if: contains(steps.changed-files.outputs.all_changed_files, '.tf')
         working-directory: ./terraform
         run: terraform init
 
       - name: Lint with trunk
+        if: ${{ always() }}
         uses: trunk-io/trunk-action@v1.0.6

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
   workflow_call:
+    inputs:
+      terraform-version:
+        required: true
+        type: number
 
 jobs:
   lint-and-test:
@@ -19,40 +23,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v35
-
-      - name: List all changed files
-        run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo "$file was changed"
-          done
-
-      - name: Output terraform working directory
-        if: contains(steps.changed-files.outputs.all_changed_files, '.tf')
-        id: terraform-dir
-        uses: tj-actions/changed-files@v35
-        with:
-          files: |
-            **/*.tf
-          dir_names: true
-          dir_names_exclude_root: true
-
-      - name: List output directories
-        run: |
-          echo "${{ steps.terraform-dir.outputs.all_changed_files }}"
+      - name: Search for terraform files
+        id: find-terraform
+        uses: ./.github/workflows/changed-files-and-dirs.yaml
 
       - name: Setup Terraform
-        if: contains(steps.changed-files.outputs.all_changed_files, '.tf')
+        if: contains(steps.find-terraform.outputs.changed-files, '.tf')
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3
+          terraform_version: ${{ inputs.terraform-version }}
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
+      #Initialise terraform in the directory where terraform file have changed.
       - name: Initialise Terraform
-        if: contains(steps.changed-files.outputs.all_changed_files, '.tf')
-        working-directory: ${{ steps.terraform-dir.outputs.all_changed_files }}
+        if: contains(steps.find-terraform.outputs.changed-files, '.tf')
+        working-directory: ${{ steps.find-terraform.outputs.dir-names }}
         run: terraform init
 
       - name: Lint with trunk

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -13,24 +13,33 @@ on:
         required: true
         type: number
 
-jobs:
-  lint-and-test:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+permissions:
+  contents: read
+  checks: write
 
+jobs:
+  find-terraform:
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.find-tf-dir.outputs.files }}
+      dir: ${{ steps.find-tf-dir.outputs.dirs }}
+
+    steps:
       - name: Search for terraform files
-        id: find-terraform
+        id: find-tf-dir
         uses: ./.github/workflows/changed-files-and-dirs.yaml
         with:
           file-type: '.tf'
 
+  lint:
+    runs-on: ubuntu-latest
+    needs: find-terraform
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Setup Terraform
-        if: contains(steps.find-terraform.outputs.changed-files, '.tf')
+        if: contains(needs.find-terraform.outputs.files, '.tf')
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ inputs.terraform-version }}
@@ -38,10 +47,10 @@ jobs:
 
       #Initialise terraform in the directory where terraform file have changed.
       - name: Initialise Terraform
-        if: contains(steps.find-terraform.outputs.changed-files, '.tf')
-        working-directory: ${{ steps.find-terraform.outputs.dir-names }}
+        if: contains(needs.find-terraform.outputs.files, '.tf')
+        working-directory: ${{ needs.find-terraform.outputs.dir }}
         run: terraform init
 
       - name: Lint with trunk
-        if: ${{ always() }}
+        if: ${{ always() }} #Run anyway, even if no terraform
         uses: trunk-io/trunk-action@v1.0.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
   # pre-commit picks up coding errors prior to committing them
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-yaml
       - id: check-json
@@ -12,12 +12,12 @@ repos:
 
   # gitleaks detects hard coded secrets
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.13.0
+    rev: v8.15.3
     hooks:
       - id: gitleaks
 
   # actionlint is a static checker for GitHub Actions workflow files
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.19
+    rev: v1.6.23
     hooks:
       - id: actionlint


### PR DESCRIPTION
The changes in this PR will output the files that have changed, which allows us to conditionally run the terraform actions if terraform files have changed. If terraform files have not changed, we can skip initialising terraform, because it does not need to be linted.

We can also use the changed files action to set the terraform working directory.