### PR TITLE
ci: Add changed-file action to lint and test

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -1,6 +1,6 @@
 name: Lint and test
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -28,14 +28,17 @@ jobs:
           done
 
       - name: Setup Terraform
+        if: contain(steps.changed-files.outputs.all_changed_files, '**/*.tf')
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.3
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Initialise Terraform
+        if: contain(steps.changed-files.outputs.all_changed_files, '**/*.tf')
         working-directory: ./terraform
         run: terraform init
 
       - name: Lint with trunk
+        if: ${{ always() }}
         uses: trunk-io/trunk-action@v1.0.6

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -31,14 +31,14 @@ jobs:
           done
 
       - name: Setup Terraform
-        if: contains(steps.changed-files.outputs.all_changed_files, '**/*.tf')
+        if: contains(steps.changed-files.outputs.all_changed_files, '.tf')
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.3
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Initialise Terraform
-        if: contains(steps.changed-files.outputs.all_changed_files, '**/*.tf')
+        if: contains(steps.changed-files.outputs.all_changed_files, '.tf')
         working-directory: ./terraform
         run: terraform init
 

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -5,6 +5,8 @@ on:
       - opened
       - edited
       - synchronize
+    branches:
+      - main
   workflow_call:
 
 jobs:

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -7,7 +7,6 @@ on:
       - synchronize
     branches:
       - main
-      - ci-lint-tf-condition
   workflow_call:
 
 jobs:

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -28,14 +28,14 @@ jobs:
           done
 
       - name: Setup Terraform
-        if: contain(steps.changed-files.outputs.all_changed_files, '**/*.tf')
+        if: contains(steps.changed-files.outputs.all_changed_files, '**/*.tf')
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.3
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Initialise Terraform
-        if: contain(steps.changed-files.outputs.all_changed_files, '**/*.tf')
+        if: contains(steps.changed-files.outputs.all_changed_files, '**/*.tf')
         working-directory: ./terraform
         run: terraform init
 

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -7,6 +7,7 @@ on:
       - synchronize
     branches:
       - main
+      - ci-lint-tf-condition
   workflow_call:
 
 jobs:


### PR DESCRIPTION
This step will output the files that have changed, which allows us to conditionally run the terraform actions if terraform files have changed. If terraform files have not changed, we can skip initialising terraform, because it does not need to be linted.