### PR TITLE
feat: Add reusable workflow for terraform-docs

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -10,6 +10,7 @@
     "conventionalcommits",
     "linters",
     "markdownlint",
+    "noreply",
     "runtimes",
     "tflint",
     "tfsec",

--- a/.github/workflows/get-terraform-dir.yaml
+++ b/.github/workflows/get-terraform-dir.yaml
@@ -37,6 +37,7 @@ jobs:
           files: |
             **/*.tf
             **/*.tfvars
+            **/*.hcl
           dir_names: true
           dir_names_exclude_root: true
 

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -6,7 +6,7 @@ jobs:
   find-terraform:
     uses: ./.github/workflows/get-terraform-dir.yaml
 
-  docs:
+  terraform-docs:
     runs-on: ubuntu-latest
     needs: find-terraform
     steps:

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -8,6 +8,8 @@ jobs:
 
   terraform-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: find-terraform
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -1,0 +1,24 @@
+name: Generate terraform docs
+on:
+  workflow_call:
+
+jobs:
+  find-terraform:
+    uses: ./.github/workflows/get-terraform-dir.yaml
+
+  docs:
+    runs-on: ubuntu-latest
+    needs: find-terraform
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Render terraform docs and push changes back to PR
+        uses: terraform-docs/gh-actions@v1.0.0
+        with:
+          working-dir: ${{ needs.find-terraform.outputs.terraform-dir }}
+          output-file: README.md
+          output-method: inject
+          git-push: "true"
+          git-commit-message: "update terraform documentation"

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -24,3 +24,9 @@ jobs:
           output-method: inject
           git-push: "true"
           git-commit-message: "update terraform documentation"
+          # See this link for configuring an apps email and username:
+          # https://github.com/orgs/community/discussions/24664
+          git-push-user-name: "3ware-release[bot]"
+          # GitHub App user ID from:
+          # https://api.github.com/users/3ware-release%5Bbot%5D
+          git-push-user-email: "108564841+3ware-release[bot]@users.noreply.github.com"


### PR DESCRIPTION
Using terraform docs with pre-commit was slowing things down, because an extra commit was required to commit the changes made by the pre-commit hook. Using the GitHub action means that changes are committed automatically in the pull request.