### PR TITLE
refactor: terraform-docs workflow

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -57,7 +57,7 @@ jobs:
           DESTINATION_BRANCH: ${{ github.event.pull_request.head.ref }}
           FILE_TO_COMMIT: "${{ env.FILE_PATH }}"
         run: |
-          export MESSAGE=" update ${{ env.TF_DOCS_FILE }} with terraform-docs
+          export MESSAGE="update ${{ env.TF_DOCS_FILE }} with terraform-docs"
           export SHA=$( git rev-parse $DESTINATION_BRANCH:$FILE_TO_COMMIT )
           export CONTENT=$( base64 -i $FILE_TO_COMMIT )
           gh api --method PUT /repos/:owner/:repo/contents/$FILE_TO_COMMIT \

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -38,6 +38,7 @@ jobs:
           KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
       - name: Render terraform docs
+        id: terraform-docs
         uses: terraform-docs/gh-actions@v1.0.0
         with:
           working-dir: ${{ needs.find-terraform.outputs.terraform-dir }}
@@ -48,16 +49,19 @@ jobs:
         run: echo "FILE_PATH=${{ env.WORKING_DIR }}/${{ env.TF_DOCS_FILE }}" >> $GITHUB_ENV
 
       # Use the REST API to commit changes, so we get automatic commit signing
+      # Only run this job if the file has changed to prevent empty commits
       - name: Push changes back to PR with signature
+        if: ${{ steps.terraform-docs.outputs.num_changed != 0 }}
         env:
           GH_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
           DESTINATION_BRANCH: ${{ github.event.pull_request.head.ref }}
           FILE_TO_COMMIT: "${{ env.FILE_PATH }}"
         run: |
+          export MESSAGE=" update ${{ env.TF_DOCS_FILE }} with terraform-docs
           export SHA=$( git rev-parse $DESTINATION_BRANCH:$FILE_TO_COMMIT )
           export CONTENT=$( base64 -i $FILE_TO_COMMIT )
           gh api --method PUT /repos/:owner/:repo/contents/$FILE_TO_COMMIT \
-            --field message="update documentation with terraform-docs" \
+            --field message="$MESSAGE" \
             --field content="$CONTENT" \
             --field encoding="base64" \
             --field branch="$DESTINATION_BRANCH" \

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -4,9 +4,11 @@ on:
 
 jobs:
   get-temp-token:
+    if: github.actor != '3ware-release[bot]'
     uses: ./.github/workflows/get-workflow-token.yaml
     secrets: inherit
   find-terraform:
+    if: github.actor != '3ware-release[bot]'
     uses: ./.github/workflows/get-terraform-dir.yaml
 
   terraform-docs:

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -3,22 +3,37 @@ on:
   workflow_call:
 
 jobs:
+  get-temp-token:
+    uses: ./.github/workflows/get-workflow-token.yaml
+    secrets: inherit
   find-terraform:
     uses: ./.github/workflows/get-terraform-dir.yaml
 
   terraform-docs:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    # only run this workflow if not triggered by 3ware-release
+    # this prevents workflow loop
+    if: github.actor != '3ware-release[bot]'
     env:
       WORKING_DIR: ${{ needs.find-terraform.outputs.terraform-dir }}
       TF_DOCS_FILE: README.md
-    needs: find-terraform
+    needs: [get-temp-token, find-terraform]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Decrypt the installation access token
+        id: decrypt-token
+        run: |
+          DECRYPTED_TOKEN=$(gpg --decrypt --quiet --batch --passphrase "$KEY" \
+          --output - <(echo "${{ needs.get-temp-token.outputs.temp-token }}" \
+          | base64 --decode))
+          echo "::add-mask::$DECRYPTED_TOKEN"
+          echo "temp-token=$DECRYPTED_TOKEN" >> $GITHUB_OUTPUT
+        env:
+          KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
       - name: Render terraform docs
         uses: terraform-docs/gh-actions@v1.0.0
@@ -33,8 +48,7 @@ jobs:
       # Use the REST API to commit changes, so we get automatic commit signing
       - name: Push changes back to PR with signature
         env:
-          # Use the GITHUB_TOKEN to prevent a recursive workflow loop
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
           DESTINATION_BRANCH: ${{ github.event.pull_request.head.ref }}
           FILE_TO_COMMIT: "${{ env.FILE_PATH }}"
         run: |
@@ -45,6 +59,4 @@ jobs:
             --field content="$CONTENT" \
             --field encoding="base64" \
             --field branch="$DESTINATION_BRANCH" \
-            --field sha="$SHA" \
-            --field 'committer[name]'="3ware-release[bot]" \
-            --field 'committer[email]'="108564841+3ware-release[bot]@users.noreply.github.com"
+            --field sha="$SHA"

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -3,9 +3,6 @@ on:
   workflow_call:
 
 jobs:
-  get-temp-token:
-    uses: ./.github/workflows/get-workflow-token.yaml
-    secrets: inherit
   find-terraform:
     uses: ./.github/workflows/get-terraform-dir.yaml
 
@@ -16,23 +13,12 @@ jobs:
     env:
       WORKING_DIR: ${{ needs.find-terraform.outputs.terraform-dir }}
       TF_DOCS_FILE: README.md
-    needs: [get-temp-token, find-terraform]
+    needs: find-terraform
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-
-      - name: Decrypt the installation access token
-        id: decrypt-token
-        run: |
-          DECRYPTED_TOKEN=$(gpg --decrypt --quiet --batch --passphrase "$KEY" \
-          --output - <(echo "${{ needs.get-temp-token.outputs.temp-token }}" \
-          | base64 --decode))
-          echo "::add-mask::$DECRYPTED_TOKEN"
-          echo "temp-token=$DECRYPTED_TOKEN" >> $GITHUB_OUTPUT
-        env:
-          KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
       - name: Render terraform docs
         uses: terraform-docs/gh-actions@v1.0.0
@@ -47,17 +33,18 @@ jobs:
       # Use the REST API to commit changes, so we get automatic commit signing
       - name: Push changes back to PR with signature
         env:
-          GH_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
+          # Use the GITHUB_TOKEN to prevent a recursive workflow loop
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DESTINATION_BRANCH: ${{ github.event.pull_request.head.ref }}
           FILE_TO_COMMIT: "${{ env.FILE_PATH }}"
         run: |
-          export TODAY=$( date -u '+%Y-%m-%d' )
-          export MESSAGE="update documentation with terraform-docs"
           export SHA=$( git rev-parse $DESTINATION_BRANCH:$FILE_TO_COMMIT )
           export CONTENT=$( base64 -i $FILE_TO_COMMIT )
           gh api --method PUT /repos/:owner/:repo/contents/$FILE_TO_COMMIT \
-            --field message="$MESSAGE" \
+            --field message="update documentation with terraform-docs" \
             --field content="$CONTENT" \
             --field encoding="base64" \
             --field branch="$DESTINATION_BRANCH" \
-            --field sha="$SHA"
+            --field sha="$SHA" \
+            --field 'committer[name]'="3ware-release[bot]" \
+            --field 'committer[email]'="108564841+3ware-release[bot]@users.noreply.github.com"

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -2,6 +2,10 @@ name: Generate terraform docs
 on:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   get-temp-token:
     if: github.actor != '3ware-release[bot]'
@@ -13,6 +17,7 @@ jobs:
 
   terraform-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # only run this workflow if not triggered by 3ware-release
     # this prevents workflow loop
     if: github.actor != '3ware-release[bot]'
@@ -51,6 +56,7 @@ jobs:
       # Use the REST API to commit changes, so we get automatic commit signing
       # Only run this job if the file has changed to prevent empty commits
       - name: Push changes back to PR with signature
+        id: push-with-sig
         if: ${{ steps.terraform-docs.outputs.num_changed != 0 }}
         env:
           GH_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
@@ -66,3 +72,16 @@ jobs:
             --field encoding="base64" \
             --field branch="$DESTINATION_BRANCH" \
             --field sha="$SHA"
+
+      - name: Summary if skipped
+        if: ${{ steps.push-with-sig.conclusion == 'skipped' }}
+        run: |
+          echo "###Push Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "Changes were not made to ${{ env.FILE_PATH }} on this run" >> $GITHUB_STEP_SUMMARY
+
+      - name: Summary if successful
+        if: ${{ steps.push-with-sig.conclusion == 'success' }}
+        run: |
+          echo "###Terraform Docs updated :rocket:" >> $GITHUB_STEP_SUMMARY
+          echo "${{ env.FILE_PATH }} add to ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Previously, commits made using 3ware-release were causing a recursive
action loop. `GITHUB_TOKEN` provides protection against this.

Resolves #28
