### PR TITLE
chore: remove terraform from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "terraform"
-    directory: "/terraform"
-    schedule:
-      interval: "monthly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This repository only contains GitHub Actions.
