### PR TITLE
fix: Remove hcl files from terraform-docs

### DIFF
--- a/.github/workflows/get-terraform-dir.yaml
+++ b/.github/workflows/get-terraform-dir.yaml
@@ -38,7 +38,6 @@ jobs:
           files: |
             **/*.tf
             **/*.tfvars
-            **/*.hcl
           dir_names: true
           dir_names_exclude_root: true
 


### PR DESCRIPTION
This action should trigger if hcl files have changed, but not return
the path of hcl files. This was causing problems when multiple
directories were returned.
