### PR TITLE
fix: lint workflow token permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,6 @@ jobs:
   lint:
     permissions:
       contents: read
-      checks: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:


### PR DESCRIPTION
`checks: write` has been removed. This is only required when the workflow posts annotations.

Resolves #43
