### PR TITLE
fix: tfsec top level workflow permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,6 +19,9 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write # not required (see slack) but produces an error in the logs
+      # https://trunkcommunity.slack.com/archives/C04GAE5EA5S/p1677846825881319?thread_ts=1676214812.584879&cid=C04GAE5EA5S
     timeout-minutes: 10
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -2,7 +2,8 @@ name: Generate terraform docs
 on: workflow_call
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   get-temp-token:

--- a/.github/workflows/tfsec-pr.yaml
+++ b/.github/workflows/tfsec-pr.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
-          persist-credentials: false
+          persist-credentials: true # tfsec step fails when false
 
       - name: Add tfsec comments to pull request
         uses: aquasecurity/tfsec-pr-commenter-action@7a44c5dcde5dfab737363e391800629e27b6376b # v1.3.1


### PR DESCRIPTION
With `persist-credentials: false` set in the checkout step, tfsec is unable to authenticate using `GITHUB_TOKEN`.
