### PR TITLE
fix: workflow token permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,17 +9,19 @@ on:
         required: true
         type: number
 
-# Declare default permissions as read only.
-permissions:
-  contents: read
+# Disable permissions for all available scopes
+permissions: {}
 
 jobs:
   find-terraform:
+    permissions:
+      contents: read
     uses: ./.github/workflows/get-terraform-dir.yaml
 
   lint:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       checks: write # not required (see slack) but produces an error in the logs
       # https://trunkcommunity.slack.com/archives/C04GAE5EA5S/p1677846825881319?thread_ts=1676214812.584879&cid=C04GAE5EA5S
     timeout-minutes: 10

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -5,9 +5,8 @@ on:
     types: [opened, edited, synchronize]
   workflow_call: {}
 
-# Declare default permissions as read only.
-permissions:
-  pull-requests: read
+# Disable permissions for all available scopes
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -15,6 +14,8 @@ concurrency:
 
 jobs:
   conventional-pr-title:
+    permissions:
+      pull-requests: read
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -12,8 +12,6 @@ jobs:
     secrets: inherit
   find-terraform:
     if: github.actor != '3ware-release[bot]'
-    permissions:
-      contents: read
     uses: ./.github/workflows/get-terraform-dir.yaml
 
   terraform-docs:

--- a/.github/workflows/tfsec-pr.yaml
+++ b/.github/workflows/tfsec-pr.yaml
@@ -9,16 +9,18 @@ on:
         required: false
         type: string
 
-# Declare default permissions as read only.
-permissions:
-  contents: read
+# Disable permissions for all available scopes
+permissions: {}
 
 jobs:
   find-terraform:
+    permissions:
+      contents: read
     uses: ./.github/workflows/get-terraform-dir.yaml
 
   tfsec-pr-commenter:
     permissions:
+      contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
This seems to be a better solution than defining `read-all` or `contents: read` at the workflow level because if write permissions are specified at the job level, read permissions from the workflow level are not inherited and must be explicitly defined at the job level as well.

Also, when calling a workflow with top-level `read-all`, it fails if the calling workflow does not have `read-all` at the job level. 
