### PR TITLE
fix: lint workflow secrets

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ on:
     inputs:
       terraform-version:
         required: true
-        type: number
+        type: string
     secrets:
       TFC_API_TOKEN:
         required: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,6 @@ on:
     secrets:
       TFC_API_TOKEN:
         required: true
-      
 
 # Disable permissions for all available scopes
 permissions: {}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,10 @@ on:
       terraform-version:
         required: true
         type: number
+    secrets:
+      TFC_API_TOKEN:
+        required: true
+      
 
 # Disable permissions for all available scopes
 permissions: {}
@@ -40,7 +44,7 @@ jobs:
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
           terraform_version: ${{ inputs.terraform-version }}
-          cli_config_credentials_token: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
+          cli_config_credentials_token: ${{ secrets.TFC_API_TOKEN }}
 
       # Initialise terraform in the directory where terraform file have changed.
       - name: Initialise Terraform


### PR DESCRIPTION
Secrets must be passed to reusable workflows from calling workflows. A secret input for the terraform cloud api token has been added to the lint workflow.