### PR TITLE
feat: 72-tfswitch

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,7 +42,7 @@ jobs:
         id: terraform-version
         if: ${{ needs.find-terraform.outputs.terraform-dir != '' }}
         run: |
-          tfswitch
+          tfswitch --chdir=${{ needs.find-terraform.outputs.terraform-dir }}
           echo "VERSION=echo $(terraform --version) | awk '{print substr($2, 2)}'" >> "$GITHUB_OUTPUT"
 
       - name: Setup Terraform

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,7 +43,7 @@ jobs:
         if: ${{ needs.find-terraform.outputs.terraform-dir != '' }}
         run: |
           tfswitch --chdir=${{ needs.find-terraform.outputs.terraform-dir }}
-          echo "VERSION=echo $(terraform --version) | awk NR==1'{print substr($2, 2)}'" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$(terraform --version | awk NR==1'{print substr($2, 2)}')" >> "$GITHUB_OUTPUT"
 
       - name: Setup Terraform
         if: ${{ needs.find-terraform.outputs.terraform-dir != '' }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,15 +41,15 @@ jobs:
       - name: Get Terraform Version
         id: terraform-version
         if: ${{ needs.find-terraform.outputs.terraform-dir != '' }}
-        #echo "VERSION=echo $(terraform --version) | awk '{print substr($2, 2)}'" >> "$GITHUB_OUTPUT"
         run: |
           tfswitch --chdir=${{ needs.find-terraform.outputs.terraform-dir }}
+          echo "VERSION=echo $(terraform --version) | awk NR==1'{print substr($2, 2)}'" >> "$GITHUB_OUTPUT"
 
       - name: Setup Terraform
         if: ${{ needs.find-terraform.outputs.terraform-dir != '' }}
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          # terraform_version: ${{ steps.terraform-version.outputs.VERSION }}
+          terraform_version: ${{ steps.terraform-version.outputs.VERSION }}
           cli_config_credentials_token: ${{ secrets.TFC_API_TOKEN }}
 
       # Initialise terraform in the directory where terraform file have changed.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,15 +41,15 @@ jobs:
       - name: Get Terraform Version
         id: terraform-version
         if: ${{ needs.find-terraform.outputs.terraform-dir != '' }}
+        #echo "VERSION=echo $(terraform --version) | awk '{print substr($2, 2)}'" >> "$GITHUB_OUTPUT"
         run: |
           tfswitch --chdir=${{ needs.find-terraform.outputs.terraform-dir }}
-          echo "VERSION=echo $(terraform --version) | awk '{print substr($2, 2)}'" >> "$GITHUB_OUTPUT"
 
       - name: Setup Terraform
         if: ${{ needs.find-terraform.outputs.terraform-dir != '' }}
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: ${{ steps.terraform-version.outputs.VERSION }}
+          # terraform_version: ${{ steps.terraform-version.outputs.VERSION }}
           cli_config_credentials_token: ${{ secrets.TFC_API_TOKEN }}
 
       # Initialise terraform in the directory where terraform file have changed.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,13 +4,9 @@ on:
     types: [opened, synchronize]
     branches: [main]
   workflow_call:
-    inputs:
-      terraform-version:
-        required: true
-        type: string
     secrets:
       TFC_API_TOKEN:
-        required: true
+        required: false
 
 # Disable permissions for all available scopes
 permissions: {}
@@ -38,11 +34,22 @@ jobs:
         with:
           persist-credentials: true # lint fails to authenticate when false
 
+      - name: Setup tfswitch
+        if: ${{ needs.find-terraform.outputs.terraform-dir != '' }}
+        uses: stv-io/action-tfswitch@b6c5e07f48a6de1934acf5e9c67bd3b21423e9e1 # v1.0.0
+
+      - name: Get Terraform Version
+        id: terraform-version
+        if: ${{ needs.find-terraform.outputs.terraform-dir != '' }}
+        run: |
+          tfswitch
+          echo "VERSION=echo $(terraform --version) | awk '{print substr($2, 2)}'" >> "$GITHUB_OUTPUT"
+
       - name: Setup Terraform
         if: ${{ needs.find-terraform.outputs.terraform-dir != '' }}
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: ${{ inputs.terraform-version }}
+          terraform_version: ${{ steps.terraform-version.outputs.VERSION }}
           cli_config_credentials_token: ${{ secrets.TFC_API_TOKEN }}
 
       # Initialise terraform in the directory where terraform file have changed.


### PR DESCRIPTION
[action-tfswitch](https://github.com/stv-io/action-tfswitch) has been added to the lint workflow to read the terraform version from the configuration and switch to the desired version. The removes the need for the calling workflow to pass the version via an input.