### PR TITLE
fix: workflow secrets

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Setup Terraform
         if: ${{ inputs.terraform-dir != '' }}
-        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           cli_config_credentials_token: ${{ secrets.TFC_API_TOKEN }}
@@ -57,4 +57,4 @@ jobs:
 
       - name: Lint with trunk
         if: ${{ always() }} # Run anyway, even if no terraform
-        uses: trunk-io/trunk-action@e5f1a3f123a2440f9cd28e036495a1c1f2a20568 # v1.1.1
+        uses: trunk-io/trunk-action@34242ec4eb8cf594887600f1f9b889e7c630ec18 # v1.19.0

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   get-temp-token:
     uses: ./.github/workflows/get-workflow-token.yaml
+    secrets: inherit
 
   semantic-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -9,6 +9,7 @@ jobs:
   get-temp-token:
     if: github.actor != '3ware-release[bot]'
     uses: ./.github/workflows/get-workflow-token.yaml
+    secrets: inherit
   find-terraform:
     if: github.actor != '3ware-release[bot]'
     uses: ./.github/workflows/get-terraform-dir.yaml


### PR DESCRIPTION
`secrets: inherit` was mistakenly removed from terraform-docs and semantic-release workflow files when calling get-temp-token.

Without this set, the relevant organisational level secrets are not passed from the calling workflow flow (terraform-docs, semantic-release) into the reusable workflow (get-temp-token).