### PR TITLE
refactor(terraform-docs)!: Add required input for `terraform-dir`

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -1,5 +1,10 @@
 name: Generate terraform docs
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      terraform-dir:
+        type: string
+        required: false
 
 # Declare default permissions as read only.
 permissions:
@@ -10,25 +15,19 @@ jobs:
     if: github.actor != '3ware-release[bot]'
     uses: 3ware/workflows/.github/workflows/get-workflow-token.yaml@ec67f76d4016824ab0c5e80194d9b17a2eae0d73 # v1.13.0
     secrets: inherit
-  find-terraform:
-    if: github.actor != '3ware-release[bot]'
-    uses: 3ware/workflows/.github/workflows/get-terraform-dir.yaml@ec67f76d4016824ab0c5e80194d9b17a2eae0d73 # v1.13.0
 
   terraform-docs:
-    needs: [get-temp-token, find-terraform]
-    strategy:
-      matrix:
-        terraform-dir: ${{ fromJSON(needs.find-terraform.outputs.terraform-dir) }}
+    needs: [get-temp-token]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
-      group: ${{ github.workflow }}-${{ github.head_ref }}-${{ fromJSON(needs.find-terraform.outputs.terraform-dir) }}
+      group: ${{ github.workflow }}-${{ github.head_ref }}-${{ inputs.terraform-dir }}
       cancel-in-progress: true
     # only run this workflow if not triggered by 3ware-release
     # this prevents workflow loop
     if: github.actor != '3ware-release[bot]'
     env:
-      WORKING_DIR: ${{ matrix.terraform-dir }}
+      WORKING_DIR: ${{ inputs.terraform-dir }}
       TF_DOCS_FILE: README.md
 
     steps:
@@ -53,7 +52,7 @@ jobs:
         id: terraform-docs
         uses: terraform-docs/gh-actions@f6d59f89a280fa0a3febf55ef68f146784b20ba0 # v1.0.0
         with:
-          working-dir: ${{ needs.find-terraform.outputs.terraform-dir }}
+          working-dir: ${{ inputs.terraform-dir }}
           output-file: ${{ env.TF_DOCS_FILE }}
           output-method: inject
 

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
-      group: ${{ github.workflow }}-${{ github.head_ref }}
+      group: ${{ github.workflow }}-${{ github.head_ref }}-${{ fromJSON(needs.find-terraform.outputs.terraform-dir) }}
       cancel-in-progress: true
     # only run this workflow if not triggered by 3ware-release
     # this prevents workflow loop

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -44,7 +44,7 @@ jobs:
           --output - <(echo "${{ needs.get-temp-token.outputs.temp-token }}" \
           | base64 --decode))
           echo "::add-mask::$DECRYPTED_TOKEN"
-          echo "temp-token=$DECRYPTED_TOKEN" >> $GITHUB_OUTPUT
+          echo "temp-token=$DECRYPTED_TOKEN" >> "$GITHUB_OUTPUT"
         env:
           KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
@@ -67,9 +67,10 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
           DESTINATION_BRANCH: ${{ github.event.pull_request.head.ref }}
+          COMMIT_SCOPE: $(awk -F"/" '{print $NF}' <<< ${{ inputs.terraform-dir }})
           FILE_TO_COMMIT: "${{ env.FILE_PATH }}"
         run: |
-          export MESSAGE="update ${{ env.TF_DOCS_FILE }} with terraform-docs"
+          export MESSAGE="docs(${{ env.COMMIT_SCOPE }}) Update README.md"
           export SHA=$( git rev-parse $DESTINATION_BRANCH:$FILE_TO_COMMIT )
           export CONTENT=$( base64 -i $FILE_TO_COMMIT )
           gh api --method PUT /repos/:owner/:repo/contents/$FILE_TO_COMMIT \

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -8,11 +8,11 @@ permissions:
 jobs:
   get-temp-token:
     if: github.actor != '3ware-release[bot]'
-    uses: ./.github/workflows/get-workflow-token.yaml
+    uses: 3ware/workflows/.github/workflows/get-terraform-dir.yaml@ec67f76d4016824ab0c5e80194d9b17a2eae0d73 # v1.13.0
     secrets: inherit
   find-terraform:
     if: github.actor != '3ware-release[bot]'
-    uses: ./.github/workflows/get-terraform-dir.yaml
+    uses: 3ware/workflows/.github/workflows/get-terraform-dir.yaml@ec67f76d4016824ab0c5e80194d9b17a2eae0d73 # v1.13.0
 
   terraform-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -4,7 +4,7 @@ on:
     inputs:
       terraform-dir:
         type: string
-        required: false
+        required: true
 
 # Declare default permissions as read only.
 permissions:

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -70,7 +70,7 @@ jobs:
           COMMIT_SCOPE: $(awk -F"/" '{print $NF}' <<< ${{ inputs.terraform-dir }})
           FILE_TO_COMMIT: "${{ env.FILE_PATH }}"
         run: |
-          export MESSAGE="docs(${{ env.COMMIT_SCOPE }}) Update README.md"
+          export MESSAGE="docs(${{ env.COMMIT_SCOPE }}): Update README.md"
           export SHA=$( git rev-parse $DESTINATION_BRANCH:$FILE_TO_COMMIT )
           export CONTENT=$( base64 -i $FILE_TO_COMMIT )
           gh api --method PUT /repos/:owner/:repo/contents/$FILE_TO_COMMIT \

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   get-temp-token:
     if: github.actor != '3ware-release[bot]'
-    uses: 3ware/workflows/.github/workflows/get-terraform-dir.yaml@ec67f76d4016824ab0c5e80194d9b17a2eae0d73 # v1.13.0
+    uses: 3ware/workflows/.github/workflows/get-workflow-token.yaml@ec67f76d4016824ab0c5e80194d9b17a2eae0d73 # v1.13.0
     secrets: inherit
   find-terraform:
     if: github.actor != '3ware-release[bot]'

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -15,6 +15,10 @@ jobs:
     uses: 3ware/workflows/.github/workflows/get-terraform-dir.yaml@ec67f76d4016824ab0c5e80194d9b17a2eae0d73 # v1.13.0
 
   terraform-docs:
+    needs: [get-temp-token, find-terraform]
+    strategy:
+      matrix:
+        terraform-dir: ${{ fromJSON(needs.find-terraform.outputs.terraform-dir) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
@@ -24,9 +28,9 @@ jobs:
     # this prevents workflow loop
     if: github.actor != '3ware-release[bot]'
     env:
-      WORKING_DIR: ${{ needs.find-terraform.outputs.terraform-dir }}
+      WORKING_DIR: ${{ matrix.terraform-dir }}
       TF_DOCS_FILE: README.md
-    needs: [get-temp-token, find-terraform]
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -23,7 +23,7 @@ module.exports = {
         "terraform-docs",
       ],
     ],
-    "signed-off-by": [1, "always", "Signed-off-by:"],
+    //"signed-off-by": [1, "always", "Signed-off-by:"],
     "subject-case": [1, "always", "sentence-case"],
     "subject-empty": [2, "never"],
     "subject-full-stop": [2, "never", "."],


### PR DESCRIPTION
_Finding_ the terraform directory has been moved to the calling workflow so that a matrix strategy can be defined if multiple terraform directories are found.
The matrix strategy will call this workflow as required. 

To achieve this, the `find-terraform` job has been removed and and a new **required** input for `terraform-dir` has been added to the `workflow_call` event trigger.