### PR TITLE
refactor(lint): Replace setup terraform with setup opentofu

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,16 +44,16 @@ jobs:
 
       - name: Setup Terraform
         if: ${{ inputs.terraform-dir != '' }}
-        uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
+        uses: opentofu/setup-opentofu@ae80d4ecaab946d8f5ff18397fbf6d0686c6d46a # v1.0.3
         with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          tofu_version: "$TERRAFORM_VERSION"
           cli_config_credentials_token: ${{ secrets.TFC_API_TOKEN }}
 
       # Initialise terraform in the directory where terraform file have changed.
       - name: Initialise Terraform
         if: ${{ inputs.terraform-dir != ''}}
         working-directory: ${{ inputs.terraform-dir }}
-        run: terraform init
+        run: tofu init
 
       - name: Lint with trunk
         if: ${{ always() }} # Run anyway, even if no terraform

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,7 +46,11 @@ jobs:
         if: ${{ inputs.terraform-dir != '' }}
         uses: opentofu/setup-opentofu@ae80d4ecaab946d8f5ff18397fbf6d0686c6d46a # v1.0.3
         with:
-          tofu_version: "$TERRAFORM_VERSION"
+          # Using workflow syntax, eg: $TERRAFORM_VERSION does not work
+          # env context must be used
+          # linting error stating: "context might be invalid" will hopefully be fixed soon
+          # https://github.com/github/vscode-github-actions/issues/47
+          tofu_version: ${{ env.TERRAFORM_VERSION }}
           cli_config_credentials_token: ${{ secrets.TFC_API_TOKEN }}
 
       # Initialise terraform in the directory where terraform file have changed.

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,16 +2,19 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.19.0
+  version: 1.21.0
+# Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
     - id: trunk
-      ref: v1.4.2
+      ref: v1.4.5
       uri: https://github.com/trunk-io/plugins
+# Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
     - node@18.12.1
     - python@3.10.8
+# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
     - actionlint@1.6.26


### PR DESCRIPTION
My local workflow uses `tofu` now. trunk is also configured to use `tofu`. Setup Terraform will download providers to `registry.terraform.io` so tofu linting, via trunk, fails because it is looking for providers in `registry.opentofu.org`.

The Setup Terraform step in the lint action has been changed to use the tofu action to overcome this - and for consistency with everything else.

Resolves #82