### PR TITLE
refactor(terraform-docs): Upgrade and improvements

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -66,11 +66,9 @@ jobs:
           echo "# :white_check_mark: Terraform docs updated $FILE_PATH" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "$TF_DOCS_FILE updated for $COMMIT_SCOPE module on $BRANCH" via pull request: >> $GITHUB_STEP_SUMMARY
-          # TODO: this link doesn't work goes to `issues` not `pull`
           echo "[#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})" >> $GITHUB_STEP_SUMMARY
 
       - name: Summary if skipped
-        # TODO: check this works
         if: ${{ steps.push-with-sig.conclusion == 'skipped' }}
         run: |
           echo "# :negative_squared_cross_mark: ${{ env.TF_DOCS_FILE }} not updated" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           echo "# :white_check_mark: Terraform docs updated $FILE_PATH" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "$FILE_TO_COMMIT updated for $COMMIT_SCOPE module on $BRANCH" via pull request: >> $GITHUB_STEP_SUMMARY
+          echo "$TF_DOCS_FILE updated for $COMMIT_SCOPE module on $BRANCH" via pull request: >> $GITHUB_STEP_SUMMARY
           # TODO: this link doesn't work goes to `issues` not `pull`
           echo "[#${{ github.event.pull_request.number }}](${{ github.event.pull_request.url }})" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -64,7 +64,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "$TF_DOCS_FILE updated for $COMMIT_SCOPE module on $BRANCH" via pull request: >> $GITHUB_STEP_SUMMARY
           # TODO: this link doesn't work goes to `issues` not `pull`
-          echo "[#${{ github.event.pull_request.number }}](${{ github.event.pull_request.url }})" >> $GITHUB_STEP_SUMMARY
+          echo "[#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})" >> $GITHUB_STEP_SUMMARY
 
       - name: Summary if skipped
         # TODO: check this works

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: true # terraform-docs unable to authenticate if false
 
       - name: Render terraform docs
         id: terraform-docs

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Render terraform docs
         id: terraform-docs

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -11,13 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  # get-temp-token:
-  #   if: github.actor != '3ware-release[bot]'
-  #   uses: 3ware/workflows/.github/workflows/get-workflow-token.yaml@ec67f76d4016824ab0c5e80194d9b17a2eae0d73 # v1.13.0
-  #   secrets: inherit
-
   terraform-docs:
-    # needs: [get-temp-token]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -25,9 +19,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ inputs.terraform-dir }}
       cancel-in-progress: true
-    # only run this workflow if not triggered by 3ware-release
-    # this prevents workflow loop
-    # if: github.actor != '3ware-release[bot]'
     env:
       WORKING_DIR: ${{ inputs.terraform-dir }}
       TF_DOCS_FILE: README.md
@@ -35,19 +26,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-        # with:
-        #   persist-credentials: false
-
-      # - name: Decrypt the installation access token
-      #   id: decrypt-token
-      #   run: |
-      #     DECRYPTED_TOKEN=$(gpg --decrypt --quiet --batch --passphrase "$KEY" \
-      #     --output - <(echo "${{ needs.get-temp-token.outputs.temp-token }}" \
-      #     | base64 --decode))
-      #     echo "::add-mask::$DECRYPTED_TOKEN"
-      #     echo "temp-token=$DECRYPTED_TOKEN" >> "$GITHUB_OUTPUT"
-      #   env:
-      #     KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
       - name: Render terraform docs
         id: terraform-docs
@@ -69,31 +47,13 @@ jobs:
         id: push-with-sig
         uses: planetscale/ghcommit-action@v0.1.6
         with:
-          commit_message: "docs(${{ env.COMMIT_SCOPE }}): Update ${{ env.TF_DOCS_FILE }}"
+          # TODO: update commit message with skip ci or similar
+          commit_message: "docs(${{ env.COMMIT_SCOPE }}): Update ${{ env.TF_DOCS_FILE }} [skip ci]"
           repo: ${{ github.repository }}
           branch: ${{ github.head_ref || github.ref_name }}
           file_pattern: ${{ env.FILE_TO_COMMIT }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Use the REST API to commit changes, so we get automatic commit signing
-      # Only run this job if the file has changed to prevent empty commits
-      # - name: Push changes back to PR with signature
-      #   id: push-with-sig
-      #   if: ${{ steps.terraform-docs.outputs.num_changed != 0 }}
-      #   env:
-      #     GH_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
-      #     DESTINATION_BRANCH: ${{ github.event.pull_request.head.ref }}
-      #   run: |
-      #     export MESSAGE="docs($COMMIT_SCOPE): Update $TF_DOCS_FILE"
-      #     export SHA=$( git rev-parse $DESTINATION_BRANCH:$FILE_PATH )
-      #     export CONTENT=$( base64 -i $FILE_PATH )
-      #     gh api --method PUT /repos/:owner/:repo/contents/$FILE_PATH \
-      #       --field message="$MESSAGE" \
-      #       --field content="$CONTENT" \
-      #       --field encoding="base64" \
-      #       --field branch="$DESTINATION_BRANCH" \
-      #       --field sha="$SHA"
 
       - name: Summary if successful
         if: ${{ steps.push-with-sig.conclusion == 'success' }}
@@ -102,7 +62,8 @@ jobs:
         run: |
           echo "# :white_check_mark: Terraform docs updated $FILE_PATH" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "$FILE_PATH added to $BRANCH" >> $GITHUB_STEP_SUMMARY
+          echo "$FILE_TO_COMMIT added to $BRANCH" >> $GITHUB_STEP_SUMMARY
+          # TODO: this link doesn't work goes to `issues` not `pull`
           echo "[#${{ github.event.pull_request.number }}](https://github.com/3ware/workflows/pull/${{ github.event.pull_request.number }})" >> $GITHUB_STEP_SUMMARY
 
       - name: Summary if skipped

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -55,8 +55,11 @@ jobs:
           output-file: ${{ env.TF_DOCS_FILE }}
           output-method: inject
 
-      - name: Set file path env
-        run: echo "FILE_PATH=${{ env.WORKING_DIR }}/${{ env.TF_DOCS_FILE }}" >> $GITHUB_ENV
+      - name: Set file path environment variable
+        if: ${{ steps.terraform-docs.outputs.num_changed != 0 }}
+        run: |
+          echo "Number of files changed = ${{ steps.terraform-docs.outputs.num_changed }}"
+          echo "FILE_PATH=${{ env.WORKING_DIR }}/${{ env.TF_DOCS_FILE }}" >> $GITHUB_ENV
 
       # Use the REST API to commit changes, so we get automatic commit signing
       # Only run this job if the file has changed to prevent empty commits

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -55,11 +55,12 @@ jobs:
           output-file: ${{ env.TF_DOCS_FILE }}
           output-method: inject
 
-      - name: Set file path environment variable
+      - name: Set environment variables
         if: ${{ steps.terraform-docs.outputs.num_changed != 0 }}
         run: |
           echo "Number of files changed = ${{ steps.terraform-docs.outputs.num_changed }}"
-          echo "FILE_PATH=${{ env.WORKING_DIR }}/${{ env.TF_DOCS_FILE }}" >> $GITHUB_ENV
+          echo "FILE_PATH=${{ env.WORKING_DIR }}/${{ env.TF_DOCS_FILE }}" >> "$GITHUB_ENV"
+          echo "COMMIT_SCOPE=$(awk -F"/" '{print $NF}' <<< ${{ inputs.terraform-dir }})" >> "$GITHUB_ENV"
 
       # Use the REST API to commit changes, so we get automatic commit signing
       # Only run this job if the file has changed to prevent empty commits
@@ -69,9 +70,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
           DESTINATION_BRANCH: ${{ github.event.pull_request.head.ref }}
-          COMMIT_SCOPE: $(awk -F"/" '{print $NF}' <<< ${{ inputs.terraform-dir }})
         run: |
-          export MESSAGE="docs(${{ env.COMMIT_SCOPE }}): Update ${{ env.TF_DOCS_FILE }}"
+          export MESSAGE="docs($COMMIT_SCOPE): Update $TF_DOCS_FILE"
           export SHA=$( git rev-parse $DESTINATION_BRANCH:$FILE_PATH )
           export CONTENT=$( base64 -i $FILE_PATH )
           gh api --method PUT /repos/:owner/:repo/contents/$FILE_PATH \

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -81,19 +81,20 @@ jobs:
             --field branch="$DESTINATION_BRANCH" \
             --field sha="$SHA"
 
-      - name: Summary if skipped
-        if: ${{ steps.push-with-sig.conclusion == 'skipped' }}
-        run: |
-          echo "### Push Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Changes were not made to ${{ env.FILE_PATH }} on this run" >> $GITHUB_STEP_SUMMARY
-
       - name: Summary if successful
         if: ${{ steps.push-with-sig.conclusion == 'success' }}
         env:
           BRANCH: ${{ github.head_ref  }}
         run: |
-          echo "### Terraform Docs updated :rocket:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $$GITHUB_STEP_SUMMARY
-          echo "${{ env.FILE_PATH }} added to $BRANCH" >> $GITHUB_STEP_SUMMARY
+          echo "# :white_check_mark: Terraform docs updated $FILE_PATH" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "$FILE_PATH added to $BRANCH" >> $GITHUB_STEP_SUMMARY
           echo "[#${{ github.event.pull_request.number }}](https://github.com/3ware/workflows/pull/${{ github.event.pull_request.number }})" >> $GITHUB_STEP_SUMMARY
+
+      - name: Summary if skipped
+        # TODO: check this works
+        if: ${{ steps.push-with-sig.conclusion == 'skipped' }}
+        run: |
+          echo "# :negative_squared_cross_mark: ${{ env.TF_DOCS_FILE }} not updated" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Changes were not required on this workflow run" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -11,21 +11,23 @@ permissions:
   contents: read
 
 jobs:
-  get-temp-token:
-    if: github.actor != '3ware-release[bot]'
-    uses: 3ware/workflows/.github/workflows/get-workflow-token.yaml@ec67f76d4016824ab0c5e80194d9b17a2eae0d73 # v1.13.0
-    secrets: inherit
+  # get-temp-token:
+  #   if: github.actor != '3ware-release[bot]'
+  #   uses: 3ware/workflows/.github/workflows/get-workflow-token.yaml@ec67f76d4016824ab0c5e80194d9b17a2eae0d73 # v1.13.0
+  #   secrets: inherit
 
   terraform-docs:
-    needs: [get-temp-token]
+    # needs: [get-temp-token]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     timeout-minutes: 5
     concurrency:
       group: ${{ github.workflow }}-${{ inputs.terraform-dir }}
       cancel-in-progress: true
     # only run this workflow if not triggered by 3ware-release
     # this prevents workflow loop
-    if: github.actor != '3ware-release[bot]'
+    # if: github.actor != '3ware-release[bot]'
     env:
       WORKING_DIR: ${{ inputs.terraform-dir }}
       TF_DOCS_FILE: README.md
@@ -33,19 +35,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-        with:
-          persist-credentials: false
+        # with:
+        #   persist-credentials: false
 
-      - name: Decrypt the installation access token
-        id: decrypt-token
-        run: |
-          DECRYPTED_TOKEN=$(gpg --decrypt --quiet --batch --passphrase "$KEY" \
-          --output - <(echo "${{ needs.get-temp-token.outputs.temp-token }}" \
-          | base64 --decode))
-          echo "::add-mask::$DECRYPTED_TOKEN"
-          echo "temp-token=$DECRYPTED_TOKEN" >> "$GITHUB_OUTPUT"
-        env:
-          KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+      # - name: Decrypt the installation access token
+      #   id: decrypt-token
+      #   run: |
+      #     DECRYPTED_TOKEN=$(gpg --decrypt --quiet --batch --passphrase "$KEY" \
+      #     --output - <(echo "${{ needs.get-temp-token.outputs.temp-token }}" \
+      #     | base64 --decode))
+      #     echo "::add-mask::$DECRYPTED_TOKEN"
+      #     echo "temp-token=$DECRYPTED_TOKEN" >> "$GITHUB_OUTPUT"
+      #   env:
+      #     KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
       - name: Render terraform docs
         id: terraform-docs
@@ -59,27 +61,39 @@ jobs:
         if: ${{ steps.terraform-docs.outputs.num_changed != 0 }}
         run: |
           echo "Number of files changed = ${{ steps.terraform-docs.outputs.num_changed }}"
-          echo "FILE_PATH=${{ env.WORKING_DIR }}/${{ env.TF_DOCS_FILE }}" >> "$GITHUB_ENV"
+          echo "FILE_TO_COMMIT=${{ env.WORKING_DIR }}/${{ env.TF_DOCS_FILE }}" >> "$GITHUB_ENV"
           echo "COMMIT_SCOPE=$(awk -F"/" '{print $NF}' <<< ${{ inputs.terraform-dir }})" >> "$GITHUB_ENV"
+
+      - name: Push verified commit
+        if: ${{ steps.terraform-docs.outputs.num_changed != 0 }}
+        id: push-with-sig
+        uses: planetscale/ghcommit-action@v0.1.6
+        with:
+          commit_message: "docs($COMMIT_SCOPE): Update $TF_DOCS_FILE"
+          repo: ${{ github.repository }}
+          branch: ${{ github.head_ref || github.ref_name }}
+          file_pattern: $FILE_TO_COMMIT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Use the REST API to commit changes, so we get automatic commit signing
       # Only run this job if the file has changed to prevent empty commits
-      - name: Push changes back to PR with signature
-        id: push-with-sig
-        if: ${{ steps.terraform-docs.outputs.num_changed != 0 }}
-        env:
-          GH_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
-          DESTINATION_BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: |
-          export MESSAGE="docs($COMMIT_SCOPE): Update $TF_DOCS_FILE"
-          export SHA=$( git rev-parse $DESTINATION_BRANCH:$FILE_PATH )
-          export CONTENT=$( base64 -i $FILE_PATH )
-          gh api --method PUT /repos/:owner/:repo/contents/$FILE_PATH \
-            --field message="$MESSAGE" \
-            --field content="$CONTENT" \
-            --field encoding="base64" \
-            --field branch="$DESTINATION_BRANCH" \
-            --field sha="$SHA"
+      # - name: Push changes back to PR with signature
+      #   id: push-with-sig
+      #   if: ${{ steps.terraform-docs.outputs.num_changed != 0 }}
+      #   env:
+      #     GH_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
+      #     DESTINATION_BRANCH: ${{ github.event.pull_request.head.ref }}
+      #   run: |
+      #     export MESSAGE="docs($COMMIT_SCOPE): Update $TF_DOCS_FILE"
+      #     export SHA=$( git rev-parse $DESTINATION_BRANCH:$FILE_PATH )
+      #     export CONTENT=$( base64 -i $FILE_PATH )
+      #     gh api --method PUT /repos/:owner/:repo/contents/$FILE_PATH \
+      #       --field message="$MESSAGE" \
+      #       --field content="$CONTENT" \
+      #       --field encoding="base64" \
+      #       --field branch="$DESTINATION_BRANCH" \
+      #       --field sha="$SHA"
 
       - name: Summary if successful
         if: ${{ steps.push-with-sig.conclusion == 'success' }}

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -70,12 +70,11 @@ jobs:
           GH_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
           DESTINATION_BRANCH: ${{ github.event.pull_request.head.ref }}
           COMMIT_SCOPE: $(awk -F"/" '{print $NF}' <<< ${{ inputs.terraform-dir }})
-          FILE_TO_COMMIT: "${{ env.FILE_PATH }}"
         run: |
-          export MESSAGE="docs(${{ env.COMMIT_SCOPE }}): Update README.md"
-          export SHA=$( git rev-parse $DESTINATION_BRANCH:$FILE_TO_COMMIT )
-          export CONTENT=$( base64 -i $FILE_TO_COMMIT )
-          gh api --method PUT /repos/:owner/:repo/contents/$FILE_TO_COMMIT \
+          export MESSAGE="docs(${{ env.COMMIT_SCOPE }}): Update ${{ env.TF_DOCS_FILE }}"
+          export SHA=$( git rev-parse $DESTINATION_BRANCH:$FILE_PATH )
+          export CONTENT=$( base64 -i $FILE_PATH )
+          gh api --method PUT /repos/:owner/:repo/contents/$FILE_PATH \
             --field message="$MESSAGE" \
             --field content="$CONTENT" \
             --field encoding="base64" \

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -69,10 +69,10 @@ jobs:
         id: push-with-sig
         uses: planetscale/ghcommit-action@v0.1.6
         with:
-          commit_message: "docs($COMMIT_SCOPE): Update $TF_DOCS_FILE"
+          commit_message: "docs(${{ env.COMMIT_SCOPE }}): Update ${{ env.TF_DOCS_FILE }}"
           repo: ${{ github.repository }}
           branch: ${{ github.head_ref || github.ref_name }}
-          file_pattern: $FILE_TO_COMMIT
+          file_pattern: ${{ env.FILE_TO_COMMIT }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -41,13 +41,13 @@ jobs:
           echo "Number of files changed = ${{ steps.terraform-docs.outputs.num_changed }}"
           echo "FILE_TO_COMMIT=${{ env.WORKING_DIR }}/${{ env.TF_DOCS_FILE }}" >> "$GITHUB_ENV"
           echo "COMMIT_SCOPE=$(awk -F"/" '{print $NF}' <<< ${{ inputs.terraform-dir }})" >> "$GITHUB_ENV"
+          echo "PR_NUMBER=${{ github.event.pull_request_review.pull_request.number }}" >> "$GITHUB_ENV"
 
       - name: Push verified commit
         if: ${{ steps.terraform-docs.outputs.num_changed != 0 }}
         id: push-with-sig
         uses: planetscale/ghcommit-action@v0.1.6
         with:
-          # TODO: update commit message with skip ci or similar
           commit_message: "docs(${{ env.COMMIT_SCOPE }}): Update ${{ env.TF_DOCS_FILE }} [skip ci]"
           repo: ${{ github.repository }}
           branch: ${{ github.head_ref || github.ref_name }}
@@ -62,9 +62,9 @@ jobs:
         run: |
           echo "# :white_check_mark: Terraform docs updated $FILE_PATH" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "$FILE_TO_COMMIT added to $BRANCH" >> $GITHUB_STEP_SUMMARY
+          echo "$FILE_TO_COMMIT updated for $COMMIT_SCOPE module on $BRANCH" via pull request: >> $GITHUB_STEP_SUMMARY
           # TODO: this link doesn't work goes to `issues` not `pull`
-          echo "[#${{ github.event.pull_request.number }}](https://github.com/3ware/workflows/pull/${{ github.event.pull_request.number }})" >> $GITHUB_STEP_SUMMARY
+          echo "[#${{ github.event.pull_request.number }}](${{ github.event.pull_request.url }})" >> $GITHUB_STEP_SUMMARY
 
       - name: Summary if skipped
         # TODO: check this works

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -32,6 +32,7 @@ lint:
         - CHANGELOG.md
 actions:
   enabled:
+    - commitlint
     - trunk-announce
     - trunk-check-pre-push
     - trunk-fmt-pre-commit


### PR DESCRIPTION
terraform-docs workflow file has been updated following the action upgrade to improve the job summaries and simplify the commit process.

The following steps have been removed:

- get-temp-token
- Set file env path
- push-with-sg

And replaced with:

- gh-commit-action

This action uses the `GITHUB_TOKEN` for authentication and the GitHub GPG key which removes the need to generate a token and push the changes with a GPG key using the gh CLI.
Expressions to prevent loops have also been removed because `GITHUB_TOKEN` does this automatically.
