### PR TITLE
refactor(lint): Terraform / Tofu  changes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,24 +33,21 @@ jobs:
         if: ${{ inputs.terraform-dir != '' }}
         uses: stv-io/action-tfswitch@b6c5e07f48a6de1934acf5e9c67bd3b21423e9e1 # v1.0.0
 
-      - name: Get Terraform Version
+      - name: Get tf version
         if: ${{ inputs.terraform-dir != '' }}
+        id: tf-version
         run: |
           tfswitch --chdir=${{ inputs.terraform-dir }}
-          echo "TERRAFORM_VERSION=$(terraform --version -json | jq -r .terraform_version)" >> "$GITHUB_ENV"
-      #TODO tofu terraform decision
-      - name: Setup Terraform
+          terraform --version
+
+      - name: Setup Tofu
         if: ${{ inputs.terraform-dir != '' }}
         uses: opentofu/setup-opentofu@ae80d4ecaab946d8f5ff18397fbf6d0686c6d46a # v1.0.3
         with:
-          # Using workflow command, eg: $TERRAFORM_VERSION does not work
-          # env context must be used
-          # linting error stating: "context might be invalid" will hopefully be fixed soon
-          # https://github.com/github/vscode-github-actions/issues/47
-          tofu_version: ${{ env.TERRAFORM_VERSION }}
+          tofu_version: ${{ steps.tf-version.outputs.terraform_version }}
 
       # Initialise terraform in the directory where terraform file have changed.
-      - name: Initialise Terraform
+      - name: Initialise Tofu
         if: ${{ inputs.terraform-dir != ''}}
         working-directory: ${{ inputs.terraform-dir }}
         run: tofu init --backend=false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,12 +41,12 @@ jobs:
         run: |
           tfswitch --chdir=${{ inputs.terraform-dir }}
           echo "TERRAFORM_VERSION=$(terraform --version -json | jq -r .terraform_version)" >> "$GITHUB_ENV"
-
+      #TODO tofu terraform decision
       - name: Setup Terraform
         if: ${{ inputs.terraform-dir != '' }}
         uses: opentofu/setup-opentofu@ae80d4ecaab946d8f5ff18397fbf6d0686c6d46a # v1.0.3
         with:
-          # Using workflow syntax, eg: $TERRAFORM_VERSION does not work
+          # Using workflow command, eg: $TERRAFORM_VERSION does not work
           # env context must be used
           # linting error stating: "context might be invalid" will hopefully be fixed soon
           # https://github.com/github/vscode-github-actions/issues/47

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,9 +8,6 @@ on:
       terraform-dir:
         type: string
         required: false
-    secrets:
-      TFC_API_TOKEN:
-        required: false
 
 # Disable permissions for all available scopes
 permissions: {}
@@ -51,14 +48,13 @@ jobs:
           # linting error stating: "context might be invalid" will hopefully be fixed soon
           # https://github.com/github/vscode-github-actions/issues/47
           tofu_version: ${{ env.TERRAFORM_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TFC_API_TOKEN }}
 
       # Initialise terraform in the directory where terraform file have changed.
       - name: Initialise Terraform
         if: ${{ inputs.terraform-dir != ''}}
         working-directory: ${{ inputs.terraform-dir }}
-        run: tofu init
+        run: tofu init --backend=false
 
       - name: Lint with trunk
         if: ${{ always() }} # Run anyway, even if no terraform
-        uses: trunk-io/trunk-action@34242ec4eb8cf594887600f1f9b889e7c630ec18 # v1.19.0
+        uses: trunk-io/trunk-action@da67635060feab46c164bc130690e61864a5d13b # v1.1.13

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -20,42 +20,43 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Validate pull request title is conventional
-        id: lint-pr-title
+      - name: Validate PR title conforms to conventional spec
+        id: validate-pr-title
         uses: amannn/action-semantic-pull-request@47b15d52c5c30e94a17ec87eb8dd51ff5221fed9 # v5.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add PR comment on failure
-        if: always() && (steps.lint-pr-title.outputs.error_message != null)
+        if: always() && (steps.validate-pr-title.outputs.error_message != null)
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
-          header: pr-title-lint-error
+          header: pr-title-error
           message: |
             Pull request titles should follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like the proposed title needs to be adjusted.
 
             Details:
 
             ```
-            ${{ steps.lint-pr-title.outputs.error_message }}
+            ${{ steps.validate-pr-title.outputs.error_message }}
             ```
 
       - name: Delete PR comment on resolution
-        if: always() && (steps.lint-pr-title.outputs.error_message == null)
+        if: always() && (steps.validate-pr-title.outputs.error_message == null)
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
-          header: pr-title-lint-error
+          header: pr-title-error
           delete: true
 
-      - name: Summary
-        if: always() && (steps.lint-pr-title.outputs.error_message == null)
+      - name: Summary with valid title
+        if: always() && (steps.validate-pr-title.outputs.error_message == null)
         run: |
           echo "# :white_check_mark: Pull Request title is valid" >> $GITHUB_STEP_SUMMARY
+          echo "The pull request title conforms to the conventional commit specification."
 
-      - name: Summary
-        if: always() && (steps.lint-pr-title.outputs.error_message != null)
+      - name: Summary without invalid title
+        if: always() && (steps.validate-pr-title.outputs.error_message != null)
         run: |
           echo "# :bangbang: Pull Request title is invalid" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "add something here depending on what the below looks like" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.lint-pr-title.outputs.error_message }}" >> $GITHUB_STEP_SUMMARY
+          echo "The pull request title does not conform to the conventional commit specification." >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.validate-pr-title.outputs.error_message }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
 
-      - name: Summary
+      - name: Summary with release
         if: ${{ steps.release.outputs.new_release_published == 'true' }}
         run: |
           echo "# :white_check_mark: New release published" >> $GITHUB_STEP_SUMMARY
@@ -62,7 +62,7 @@ jobs:
           echo ""
           echo "${{ steps.release.outputs.new_release_notes }}" >>$GITHUB_STEP_SUMMARY
 
-      - name: Summary
+      - name: Summary without release
         if: ${{ steps.release.outputs.new_release_published == 'false' }}
         run: |
           echo "# :negative_squared_cross_mark: No release published" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The repository contains [GitHub Action](https://docs.github.com/en/actions) [reu
       - [Use the token for authentication](#use-the-token-for-authentication)
     - [lint](#lint)
     - [pr-title](#pr-title)
-    - [semantic-release](#semantic-release)
+    - [release](#release)
     - [terraform-docs](#terraform-docs)
 
 ## Workflows
@@ -108,20 +108,20 @@ calling-workflow:
     GITHUB_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
 ```
 
-Thanks to this [this blog post](https://nitratine.net/blog/post/how-to-pass-secrets-between-runners-in-github-actions/) and [stack overflow answer](https://stackoverflow.com/a/75387551/18073694) for the wise words. See [get-workflow-token](https://github.com/3ware/workflows/blob/main/.github/workflows/get-workflow-token.yaml) and [semantic-release](https://github.com/3ware/workflows/blob/main/.github/workflows/semantic-release.yaml) for complete workflows.
+Thanks to this [this blog post](https://nitratine.net/blog/post/how-to-pass-secrets-between-runners-in-github-actions/) and [stack overflow answer](https://stackoverflow.com/a/75387551/18073694) for the wise words. See [get-workflow-token](https://github.com/3ware/workflows/blob/main/.github/workflows/get-workflow-token.yaml) and [release](https://github.com/3ware/workflows/blob/main/.github/workflows/semantic-release.yaml) for complete workflows.
 
 ### lint
 
-Linting is performed using [trunk.io](https://github.com/trunk-io/trunk-action). This action makes use of the [get-terraform-dir](#get-terraform-dir) workflow, to find the terraform working directory and initialise terraform, if any terraform files have been updated, so validation and linting using [tflint](https://github.com/terraform-linters/tflint) can be performed.
+Linting is performed using [trunk.io](https://github.com/trunk-io/trunk-action). This action makes use of the [get-terraform-dir](#get-terraform-dir) workflow to find the terraform working directory and initialise terraform, if any terraform files have been updated, so validation and linting, using [tflint](https://github.com/terraform-linters/tflint), can be performed.
 
 ### pr-title
 
-This workflow ensures that Pull Request titles follow the [conventional syntax](https://www.conventionalcommits.org/en/v1.0.0-beta.2/) using the [semantic-pull-request](https://github.com/marketplace/actions/semantic-pull-request) action. When the Pull Request is Squashed & Merged into main, the Pull Request title is used as the commit message, which is analysed by [semantic-release](#semantic-release)
+This workflow ensures that Pull Request titles follow the [conventional syntax](https://www.conventionalcommits.org/en/v1.0.0-beta.2/) using the [semantic-pull-request](https://github.com/marketplace/actions/semantic-pull-request) action. When the Pull Request is Squashed & Merged into main, the Pull Request title is used as the commit message, which is analysed by the [release](#release) workflow.
 
-### semantic-release
+### release
 
 [Semantic Release](https://github.com/marketplace/actions/action-for-semantic-release) generates tags and releases by mapping conventional commit messages to major, minor and patch version numbers. This action requires an authentication token to push the changes it generates to protected branches. It makes use of the [get-workflow-token](#get-workflow-token) for this, instead of using a PAT.
 
 ### terraform-docs
 
-[Terraform docs](https://github.com/marketplace/actions/terraform-docs-gh-actions) generates terraform module documentation and commits the updated _README_ to the repository. This workflow uses [get-workflow-token](#get-workflow-token) for authentication and the `gh cli` for commits, as opposed to the native functionality because commits can be signed using the former. See [this gist](https://gist.github.com/swinton/03e84635b45c78353b1f71e41007fc7c).
+[Terraform docs](https://github.com/marketplace/actions/terraform-docs-gh-actions) generates terraform module documentation and commits the updated _README_ to the repository. This workflow uses [get-workflow-token](#get-workflow-token) for authentication and [ghcommit-action](https://github.com/planetscale/ghcommit-action) to push the updated README with a verified commit.


### PR DESCRIPTION
The Initialise Tofu step in the lint workflow has been configured with `--backend=false` because native validation and tflint do not required the backend to be initialised. The TF Cloud API token input is now surplus to requirements and has been removed.

Setup Tofu has been configured to use the native output of the tfswitch action to use as the tf version.