### PR TITLE
feat(release)!: Remove `contents: read` permissions

### DIFF
--- a/.github/workflows/get-workflow-token.yaml
+++ b/.github/workflows/get-workflow-token.yaml
@@ -7,9 +7,8 @@ on:
         description: The temporary installation access token
         value: ${{ jobs.get-temp-token.outputs.token }}
 
-# Declare default permissions as read only.
-permissions:
-  contents: read
+# Disable permissions for all available scopes
+permissions: {}
 
 jobs:
   get-temp-token:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,8 @@ on:
   push:
     branches: [main]
 
-# Declare default permissions as read only.
-permissions:
-  contents: read
+# Disable permissions for all available scopes
+permissions: {}
 
 jobs:
   get-temp-token:


### PR DESCRIPTION
The release workflow uses a token generated from the 3ware release GitHub App, therefore should not need to use `GITHUB_TOKEN` permissions meaning all scopes can be disabled.