### PR TITLE
fix(release): Checkout step authentication

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,11 +22,6 @@ jobs:
       cancel-in-progress: true
     needs: [get-temp-token]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-        with:
-          persist-credentials: false
-
       - name: Decrypt the installation access token
         id: decrypt-token
         run: |
@@ -37,6 +32,12 @@ jobs:
           echo "temp-token=$DECRYPTED_TOKEN" >> $GITHUB_OUTPUT
         env:
           KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+
+      - name: Checkout repository
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          token: ${{ steps.decrypt-token.outputs.temp-token }}
+          persist-credentials: false
 
       - name: Create GitHub release and update CHANGELOG
         id: release


### PR DESCRIPTION
The checkout step in the workflow has been updated to use the token generated by the get-temp-token step for authentication.

This should resolve #96 and enable authenticated checkouts of private repositories.
