### PR TITLE
feat!: Remove `contents: read` workflow permission

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,8 +10,8 @@ on:
     types: [opened, synchronize]
     branches: [main]
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -19,6 +19,8 @@ concurrency:
 
 jobs:
   dependency-review:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/get-terraform-dir.yaml
+++ b/.github/workflows/get-terraform-dir.yaml
@@ -6,14 +6,15 @@ on:
         description: The terraform directory to initialise
         value: ${{ jobs.terraform-directory.outputs.terraform-matrix }}
 
-# Declare default permissions as read only.
-permissions:
-  contents: read
+# Disable permissions for all available scopes
+permissions: {}
 
 # TODO: Define single list of files to use in both steps
 # See: https://github.com/3ware/workflows/issues/101
 jobs:
   terraform-directory:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add PR comment on failure
-        if: always() && (steps.validate-pr-title.outputs.error_message != null)
+        if: ${{ always() && steps.validate-pr-title.outputs.error_message != null }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: pr-title-error
@@ -41,20 +41,20 @@ jobs:
             ```
 
       - name: Delete PR comment on resolution
-        if: always() && (steps.validate-pr-title.outputs.error_message == null)
+        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: pr-title-error
           delete: true
 
       - name: Summary with valid title
-        if: always() && (steps.validate-pr-title.outputs.error_message == null)
+        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null }}
         run: |
           echo "# :white_check_mark: Pull Request title is valid" >> $GITHUB_STEP_SUMMARY
           echo "The pull request title conforms to the conventional commit specification."
 
       - name: Summary without invalid title
-        if: always() && (steps.validate-pr-title.outputs.error_message != null)
+        if: ${{ always() && steps.validate-pr-title.outputs.error_message != null }}
         run: |
           echo "# :bangbang: Pull Request title is invalid" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -6,9 +6,8 @@ on:
         type: string
         required: true
 
-# Declare default permissions as read only.
-permissions:
-  contents: read
+# Disable permissions for all available scopes
+permissions: {}
 
 jobs:
   terraform-docs:


### PR DESCRIPTION
For consistency with other workflows, the permissions scope for `GITHUB_TOKEN` has been set to `{}` at the workflow level and the relevant permissions have been added at the job level.