### PR TITLE
fix(security): Pin action version to SHA

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: Upload artifact
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: SARIF file
           path: results.sarif
@@ -68,6 +68,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@2bbafcdd7fbf96243689e764c2f15d9735164f33 # v3.26.6
         with:
           sarif_file: results.sarif

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Push verified commit
         if: ${{ steps.terraform-docs.outputs.num_changed != 0 }}
         id: push-with-sig
-        uses: planetscale/ghcommit-action@v0.1.6
+        uses: planetscale/ghcommit-action@c7915d6c18d5ce4eb42b0eff3f10a29fe0766e4c # v0.1.44
         with:
           commit_message: "docs(terraform): Update ${{ env.TF_DOCS_FILE }}"
           repo: ${{ github.repository }}


### PR DESCRIPTION
Latest code scanning report from the OSSF action revealed 2 upstream actions using version numbers and not SHAs.