### PR TITLE
ci(trunk): Add inputs to the trunk upgrade action

### DIFF
--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -1,14 +1,21 @@
 name: Trunk Upgrade
 on:
   schedule:
-    - cron: 0 1 * * 1
+    - cron: 0 1 * * 2
   workflow_dispatch: {}
+
 permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.repository }}
   cancel-in-progress: true
+
 jobs:
+  get-temp-token:
+    uses: 3ware/workflows/.github/workflows/get-workflow-token.yaml@57a900982a56bebaf91e660a56adb7f021690d15 # v4.0.0
+    secrets: inherit
+
   trunk-upgrade:
+    needs: [get-temp-token]
     name: Upgrade Trunk
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -18,5 +25,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Decrypt the installation access token
+        id: decrypt-token
+        run: |
+          DECRYPTED_TOKEN=$(gpg --decrypt --quiet --batch --passphrase "$KEY" \
+          --output - <(echo "${{ needs.get-temp-token.outputs.temp-token }}" \
+          | base64 --decode))
+          echo "::add-mask::$DECRYPTED_TOKEN"
+          echo "temp-token=$DECRYPTED_TOKEN" >> $GITHUB_OUTPUT
+
       - name: Trunk Upgrade
         uses: trunk-io/trunk-action/upgrade@8e4c812061ece3fa253bbfa5a80ee1caefa19eb1 # v1.22.9
+        with:
+          github-token: ${{ steps.decrypt-token.outputs.temp-token }}
+          prefix: "ci(trunk):"


### PR DESCRIPTION
The trunk upgrade action has been configured with a `prefix` input to ensure the PR title follows the conventional standard. 

GitHup App authentication has also been added because the other workflows do not run when `github-actions[bot]` creates the pull request.