### PR TITLE
ci(trunk): Add PGP key environment variable

### DIFF
--- a/.github/workflows/get-workflow-token.yaml
+++ b/.github/workflows/get-workflow-token.yaml
@@ -27,10 +27,10 @@ jobs:
 
       - name: Encrypt the token for reuse between jobs / workflows
         id: encrypt-token
+        env:
+          KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+          TOKEN: ${{ steps.get-workflow-token.outputs.token }}
         run: |
           ENCRYPTED_TOKEN=$(gpg --symmetric --batch --passphrase "$KEY" \
             --output - <(echo "$TOKEN") | base64 -w0)
           echo "encrypted-token=$ENCRYPTED_TOKEN" >> $GITHUB_OUTPUT
-        env:
-          KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
-          TOKEN: ${{ steps.get-workflow-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,14 +23,14 @@ jobs:
     steps:
       - name: Decrypt the installation access token
         id: decrypt-token
+        env:
+          KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
         run: |
           DECRYPTED_TOKEN=$(gpg --decrypt --quiet --batch --passphrase "$KEY" \
           --output - <(echo "${{ needs.get-temp-token.outputs.temp-token }}" \
           | base64 --decode))
           echo "::add-mask::$DECRYPTED_TOKEN"
           echo "temp-token=$DECRYPTED_TOKEN" >> $GITHUB_OUTPUT
-        env:
-          KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -29,14 +29,14 @@ jobs:
     steps:
       - name: Decrypt the installation access token
         id: decrypt-token
+        env:
+          KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
         run: |
           DECRYPTED_TOKEN=$(gpg --decrypt --quiet --batch --passphrase "$KEY" \
           --output - <(echo "${{ needs.get-temp-token.outputs.temp-token }}" \
           | base64 --decode))
           echo "::add-mask::$DECRYPTED_TOKEN"
           echo "temp-token=$DECRYPTED_TOKEN" >> $GITHUB_OUTPUT
-        env:
-          KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Decrypt the installation access token
         id: decrypt-token
+        env:
+          KEY: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
         run: |
           DECRYPTED_TOKEN=$(gpg --decrypt --quiet --batch --passphrase "$KEY" \
           --output - <(echo "${{ needs.get-temp-token.outputs.temp-token }}" \


### PR DESCRIPTION
The PGP key is required to decrypt the token generated by the get-temp-token job. This is a sensitive value so it must be encrypted between jobs.