### PR TITLE
feat(checks): Add auto-approve job for trunk upgrade PRs

### DIFF
--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Auto Approve PR
         if: ${{ github.actor == '3ware-release[bot]' && github.head_ref == 'trunk-io/update-trunk' }}
-        uses: hmarr/auto-approve-action@v4
+        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:
           github-token: ${{ secrets.PR_APPROVAL_PAT }}
           review-message: All checks passed. Auto Approved.

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -1,7 +1,7 @@
 name: Checks
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
     branches: [main]
 
@@ -23,3 +23,17 @@ jobs:
         uses: poseidon/wait-for-status-checks@6988432d64ad3f9c2608db4ca16fded1b7d36ead # v0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Approve PR raised by 3ware-release[bot] to upgrade trunk on trunk branches
+  # after all checks have passed.
+  auto-approve-pr:
+    needs: [enforce-all-checks]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Auto Approve PR
+        if: ${{ github.actor == '3ware-release[bot]' && github.head_ref == 'trunk-io/update-trunk' }}
+        uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.PR_APPROVAL_PAT }}
+          review-message: All checks passed. Auto Approved.


### PR DESCRIPTION
Pull requests raised by trunk to upgrade itself and the enabled linters can be auto approved once the required checks have passed.

A job to perform this action has been added to the 'checks' workflow. Once the checks job has completed, and the PR is raised by `3ware-release[bot]` on the `trunk-io/update-trunk` branch, the approval job will run.