### PR TITLE
feat(pr-title): Add check for title length

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -13,8 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
-env:
-  PR_TITLE_LENGTH: 72
+# env:
+#   PR_TITLE_LENGTH: 72
 
 jobs:
   validate-pr-title:
@@ -28,15 +28,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: amannn/action-semantic-pull-request@47b15d52c5c30e94a17ec87eb8dd51ff5221fed9 # v5.3.0
+        with:
+          # Use the conventional commit pattern with maximum length of 72 characters
+          headerPattern: '^(?=.{1,72}$)(\w*)(?:\(([\w\$\.\-\* ]*)\))?\: (.*)$'
+          headerPatternCorrespondence: type, scope, subject
+          requireScope: true
+          subjectPattern: ^([A-Z]).+$ # Subject must start with an upper case character
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. The subject must be sentence case.
+            Please start the subject with an upper case character.
+          # TODO: Required scopes for this repo and as an input when called
 
       # Using an action here because github.event.pull_request.title is flagged as potentially untrusted and assigning to an
       # intermediate variable did not resolve this. GitHub recommends using an action to mitigate script injection attacks.
       # https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks
-      - name: PR title length
-        id: pr-title-length
-        uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2
-        with:
-          max_length: ${{ env.PR_TITLE_LENGTH }}
+      # - name: PR title length
+      #   id: pr-title-length
+      #   uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2
+      #   with:
+      #     max_length: ${{ env.PR_TITLE_LENGTH }}
 
       - name: Add PR comment on conventional failure
         if: ${{ always() && steps.validate-pr-title.outputs.error_message != null }}
@@ -54,33 +65,33 @@ jobs:
 
             Please update the pull request title to follow the Conventional Commits specification.
 
-      #TODO: test this, what happens to the PR comment if both tests fail?
-      - name: Add PR comment on length failure
-        if: ${{ always() && steps.pr-title-length.outcome == 'failure' }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-        with:
-          header: pr-title-error
-          message: |
-            Pull request titles should be less than ${{ env.PR_TITLE_LENGTH }} characters.
+      # - name: Add PR comment on length failure
+      #   if: ${{ always() && steps.pr-title-length.outcome == 'failure' }}
+      #   uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+      #   with:
+      #     header: pr-title-error
+      #     message: |
+      #       Pull request titles should be less than ${{ env.PR_TITLE_LENGTH }} characters.
 
-            The maximum length for a pull request title is ${{ env.PR_TITLE_LENGTH }} characters because 'Squash & Merge' is used to merge pull requests -
-            and commit messages should be a maximum of ${{ env.PR_TITLE_LENGTH }} characters.
+      #       The maximum length for a pull request title is ${{ env.PR_TITLE_LENGTH }} characters because 'Squash & Merge' is used to merge pull requests -
+      #       and commit messages should be a maximum of ${{ env.PR_TITLE_LENGTH }} characters.
 
-            Please update the pull request title to be fewer than ${{ env.PR_TITLE_LENGTH }} characters.
+      #       Please update the pull request title to be fewer than ${{ env.PR_TITLE_LENGTH }} characters.
 
       - name: Delete PR comment on resolution
-        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null && steps.pr-title-length.outcome == 'success' }}
+        # if: ${{ always() && steps.validate-pr-title.outputs.error_message == null && steps.pr-title-length.outcome == 'success' }}
+        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: pr-title-error
           delete: true
 
       - name: Summary with valid title
-        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null && steps.pr-title-length.outcome == 'success' }}
+        # if: ${{ always() && steps.validate-pr-title.outputs.error_message == null && steps.pr-title-length.outcome == 'success' }}
+        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null }}
         run: |
           echo "### :white_check_mark: Pull Request title is valid" >> $GITHUB_STEP_SUMMARY
           echo "The pull request title conforms to the conventional commit specification." >> $GITHUB_STEP_SUMMARY
-          echo "The pull request title is less than ${{ env.PR_TITLE_LENGTH }} characters." >> $GITHUB_STEP_SUMMARY
 
       - name: Summary with invalid title
         if: ${{ always() && steps.validate-pr-title.outputs.error_message != null }}
@@ -90,9 +101,9 @@ jobs:
           echo "The pull request title does not conform to the conventional commit specification." >> $GITHUB_STEP_SUMMARY
           echo ${{ steps.validate-pr-title.outputs.error_message }} >> $GITHUB_STEP_SUMMARY
 
-      - name: Summary with invalid length
-        if: ${{ always() && steps.pr-title-length.outcome == 'failure' }}
-        run: |
-          echo "### :x: Pull Request title length is invalid" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The pull request title is longer than ${{ env.PR_TITLE_LENGTH }} characters." >> $GITHUB_STEP_SUMMARY
+      # - name: Summary with invalid length
+      #   if: ${{ always() && steps.pr-title-length.outcome == 'failure' }}
+      #   run: |
+      #     echo "### :x: Pull Request title length is invalid" >> $GITHUB_STEP_SUMMARY
+      #     echo "" >> $GITHUB_STEP_SUMMARY
+      #     echo "The pull request title is longer than ${{ env.PR_TITLE_LENGTH }} characters." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
+env:
+  PR_TITLE_LENGTH: 72
+
 jobs:
   validate-pr-title:
     permissions:
@@ -22,17 +25,26 @@ jobs:
     steps:
       - name: Validate PR title conforms to conventional spec
         id: validate-pr-title
-        uses: amannn/action-semantic-pull-request@47b15d52c5c30e94a17ec87eb8dd51ff5221fed9 # v5.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: amannn/action-semantic-pull-request@47b15d52c5c30e94a17ec87eb8dd51ff5221fed9 # v5.3.0
 
-      - name: Add PR comment on failure
+      # Using an action here because github.event.pull_request.title is flagged as potentially untrusted and assigning to an
+      # intermediate variable did not resolve this. GitHub recommends using an action to mitigate script injection attacks.
+      # https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks
+      - name: PR title length
+        id: pr-title-length
+        uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2
+        with:
+          max_length: ${{ env.PR_TITLE_LENGTH }}
+
+      - name: Add PR comment on conventional failure
         if: ${{ always() && steps.validate-pr-title.outputs.error_message != null }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: pr-title-error
           message: |
-            Pull request titles should follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like the proposed title needs to be adjusted.
+            Pull request titles should follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
 
             Details:
 
@@ -40,23 +52,47 @@ jobs:
             ${{ steps.validate-pr-title.outputs.error_message }}
             ```
 
+            Please update the pull request title to follow the Conventional Commits specification.
+
+      #TODO: test this, what happens to the PR comment if both tests fail?
+      - name: Add PR comment on length failure
+        if: ${{ always() && steps.pr-title-length.outcome == 'failure' }}
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: pr-title-error
+          message: |
+            Pull request titles should be less than ${{ env.PR_TITLE_LENGTH }} characters.
+
+            The maximum length for a pull request title is ${{ env.PR_TITLE_LENGTH }} characters because 'Squash & Merge' is used to merge pull requests -
+            and commit messages should be a maximum of ${{ env.PR_TITLE_LENGTH }} characters.
+
+            Please update the pull request title to be fewer than ${{ env.PR_TITLE_LENGTH }} characters.
+
       - name: Delete PR comment on resolution
-        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null }}
+        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null && steps.pr-title-length.outcome == 'success' }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: pr-title-error
           delete: true
 
       - name: Summary with valid title
-        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null }}
+        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null && steps.pr-title-length.outcome == 'success' }}
         run: |
           echo "### :white_check_mark: Pull Request title is valid" >> $GITHUB_STEP_SUMMARY
           echo "The pull request title conforms to the conventional commit specification." >> $GITHUB_STEP_SUMMARY
+          echo "The pull request title is less than ${{ env.PR_TITLE_LENGTH }} characters." >> $GITHUB_STEP_SUMMARY
 
-      - name: Summary without invalid title
+      - name: Summary with invalid title
         if: ${{ always() && steps.validate-pr-title.outputs.error_message != null }}
         run: |
           echo "### :x: Pull Request title is invalid" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "The pull request title does not conform to the conventional commit specification." >> $GITHUB_STEP_SUMMARY
           echo ${{ steps.validate-pr-title.outputs.error_message }} >> $GITHUB_STEP_SUMMARY
+
+      - name: Summary with invalid length
+        if: ${{ always() && steps.pr-title-length.outcome == 'failure' }}
+        run: |
+          echo "### :x: Pull Request title length is invalid" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The pull request title is longer than ${{ env.PR_TITLE_LENGTH }} characters." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -27,6 +27,8 @@ jobs:
         id: validate-pr-title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Cannot test with act. See:
+        # https://github.com/amannn/action-semantic-pull-request/issues/248
         uses: amannn/action-semantic-pull-request@47b15d52c5c30e94a17ec87eb8dd51ff5221fed9 # v5.3.0
         with:
           # Use the conventional commit pattern with maximum length of 72 characters

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Summary without invalid title
         if: ${{ always() && steps.validate-pr-title.outputs.error_message != null }}
         run: |
-          echo "### :bangbang: Pull Request title is invalid" >> $GITHUB_STEP_SUMMARY
+          echo "### :x: Pull Request title is invalid" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "The pull request title does not conform to the conventional commit specification." >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.validate-pr-title.outputs.error_message }}" >> $GITHUB_STEP_SUMMARY
+          echo ${{ steps.validate-pr-title.outputs.error_message }} >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -3,7 +3,7 @@ name: Validate PR title
 on:
   pull_request:
     types: [opened, edited, synchronize]
-    branches: [main]
+    #branches: [main]
   workflow_call: {}
 
 # Disable permissions for all available scopes
@@ -13,11 +13,54 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
-# env:
-#   PR_TITLE_LENGTH: 72
+defaults:
+  run:
+    shell: bash
+
+env:
+  MAX_PR_TITLE_LENGTH: 72
 
 jobs:
+  pr-title-length:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Get PR title length
+        id: pr-title-length
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "PR_TITLE_LENGTH=$(gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq '.title' | wc -c)" >> "$GITHUB_ENV"
+
+      - name: Add PR comment on failure
+        # Only add a comment if the PR title is too long
+        # fromJson is required to convert the string to a number
+        if: ${{ fromJson(env.PR_TITLE_LENGTH) > fromJson(env.MAX_PR_TITLE_LENGTH) }}
+        id: pr-comment
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: pr-title-error
+          message: |
+            Hi and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles be limited to ${{ env.MAX_PR_TITLE_LENGTH }} characters.
+            This is because we use `Squash and Merge` for pull requests with the title as the commit message.
+
+            Please update the title to be ${{ env.MAX_PR_TITLE_LENGTH }} characters or less. If you need help, feel free to ask! 😊
+
+      - name: Exit if PR title is too long
+        if: ${{ fromJson(env.PR_TITLE_LENGTH) > fromJson(env.MAX_PR_TITLE_LENGTH) }}
+        run: |
+          echo "### :x: Pull Request title is invalid" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The pull request title is too long. Please update the title to be ${{ env.MAX_PR_TITLE_LENGTH }} characters or less." >> $GITHUB_STEP_SUMMARY
+          exit 1
+
   validate-pr-title:
+    # Run if PR title length job does not exit
+    needs: [pr-title-length]
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
@@ -31,33 +74,30 @@ jobs:
         # https://github.com/amannn/action-semantic-pull-request/issues/248
         uses: amannn/action-semantic-pull-request@47b15d52c5c30e94a17ec87eb8dd51ff5221fed9 # v5.3.0
         with:
-          # Use the conventional commit pattern with maximum length of 72 characters
-          headerPattern: '^(?=.{1,72}$)(\w*)(?:\(([\w\$\.\-\* ]*)\))?\: (.*)$'
-          headerPatternCorrespondence: type, scope, subject
           requireScope: true
+          # TODO: Required scopes for this repo and as an input when called
+          # TODO: Add scopes to PR comment if applicable
+          # scopes: Ideally get them from the commitlint config file to avoid duplication
+          # Maybe use this action; will require commitlint.config.js changing to .commitlintrc.json
+          # https://github.com/marketplace/actions/get-properties-from-json-file
           subjectPattern: ^([A-Z]).+$ # Subject must start with an upper case character
           subjectPatternError: |
-            The subject "{subject}" found in the pull request title "{title}"
-            didn't match the configured pattern. The subject must be sentence case.
+            The subject "{subject}" found in the pull request title
+            "{title}" didn't match the configured pattern.
+            The subject must be sentence case.
             Please start the subject with an upper case character.
-          # TODO: Required scopes for this repo and as an input when called
 
-      # Using an action here because github.event.pull_request.title is flagged as potentially untrusted and assigning to an
-      # intermediate variable did not resolve this. GitHub recommends using an action to mitigate script injection attacks.
-      # https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks
-      # - name: PR title length
-      #   id: pr-title-length
-      #   uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2
-      #   with:
-      #     max_length: ${{ env.PR_TITLE_LENGTH }}
-
-      - name: Add PR comment on conventional failure
+      - name: Add PR comment on failure
+        # Only add a comment if the error message is not null or the PR title is too long
         if: ${{ always() && steps.validate-pr-title.outputs.error_message != null }}
+        id: pr-comment
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: pr-title-error
           message: |
-            Pull request titles should follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
+            Hi and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
 
             Details:
 
@@ -65,23 +105,10 @@ jobs:
             ${{ steps.validate-pr-title.outputs.error_message }}
             ```
 
-            Please update the pull request title to follow the Conventional Commits specification.
-
-      # - name: Add PR comment on length failure
-      #   if: ${{ always() && steps.pr-title-length.outcome == 'failure' }}
-      #   uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-      #   with:
-      #     header: pr-title-error
-      #     message: |
-      #       Pull request titles should be less than ${{ env.PR_TITLE_LENGTH }} characters.
-
-      #       The maximum length for a pull request title is ${{ env.PR_TITLE_LENGTH }} characters because 'Squash & Merge' is used to merge pull requests -
-      #       and commit messages should be a maximum of ${{ env.PR_TITLE_LENGTH }} characters.
-
-      #       Please update the pull request title to be fewer than ${{ env.PR_TITLE_LENGTH }} characters.
+            Please update the title to follow the conventional commit specification. If you need help, feel free to ask! 😊
 
       - name: Delete PR comment on resolution
-        # if: ${{ always() && steps.validate-pr-title.outputs.error_message == null && steps.pr-title-length.outcome == 'success' }}
+        # Delete comment if the error message is null or the PR title is the correct length
         if: ${{ always() && steps.validate-pr-title.outputs.error_message == null }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
@@ -89,7 +116,7 @@ jobs:
           delete: true
 
       - name: Summary with valid title
-        # if: ${{ always() && steps.validate-pr-title.outputs.error_message == null && steps.pr-title-length.outcome == 'success' }}
+        # A length check is not required here because the validate-pr-title step will only run if the title is less than or equal to the max length
         if: ${{ always() && steps.validate-pr-title.outputs.error_message == null }}
         run: |
           echo "### :white_check_mark: Pull Request title is valid" >> $GITHUB_STEP_SUMMARY
@@ -97,15 +124,13 @@ jobs:
 
       - name: Summary with invalid title
         if: ${{ always() && steps.validate-pr-title.outputs.error_message != null }}
+        env:
+          # Set to comment ID if a comment was created, otherwise set to previous comment ID
+          COMMENT_ID: ${{ steps.pr-comment.outputs.created_comment_id || steps.pr-comment.outputs.previous_comment_id }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           echo "### :x: Pull Request title is invalid" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "The pull request title does not conform to the conventional commit specification." >> $GITHUB_STEP_SUMMARY
-          echo ${{ steps.validate-pr-title.outputs.error_message }} >> $GITHUB_STEP_SUMMARY
-
-      # - name: Summary with invalid length
-      #   if: ${{ always() && steps.pr-title-length.outcome == 'failure' }}
-      #   run: |
-      #     echo "### :x: Pull Request title length is invalid" >> $GITHUB_STEP_SUMMARY
-      #     echo "" >> $GITHUB_STEP_SUMMARY
-      #     echo "The pull request title is longer than ${{ env.PR_TITLE_LENGTH }} characters." >> $GITHUB_STEP_SUMMARY
+          echo "Please see pull request comments for more details on how to resolve this:" >> $GITHUB_STEP_SUMMARY
+          echo "[Pull Request Comment](${{ env.PR_URL }}#issuecomment-${{ env.COMMENT_ID }})" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-vagrant
+# File containing test event payloads to use with act
+payload.json

--- a/testfile.txt
+++ b/testfile.txt
@@ -1,0 +1,1 @@
+A PR to Test the new PR title functionality


### PR DESCRIPTION
This repository uses 'Squash & Merge' with a default commit message of 'Pull Request Title' when merging pull requests. Most _good commit message_ guides suggest a commit message length of 72. A check has been added to ensure the length of the pull request title does not exceed 72 characters.  