### PR TITLE
fix(checks): Amend job execution conditions

### DIFF
--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -1,6 +1,9 @@
 name: Checks
 
 on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    branches: [main]
   pull_request_target:
     types: [opened, edited, synchronize]
     branches: [main]
@@ -14,6 +17,7 @@ concurrency:
 
 jobs:
   enforce-all-checks:
+    if: ${{ github.event_name == 'pull_request' }}
     permissions:
       checks: read
     runs-on: ubuntu-latest

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -27,12 +27,12 @@ jobs:
   # Approve PR raised by 3ware-release[bot] to upgrade trunk on trunk branches
   # after all checks have passed.
   auto-approve-pr:
+    if: ${{ github.actor == '3ware-release[bot]' && github.head_ref == 'trunk-io/update-trunk' }}
     needs: [enforce-all-checks]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Auto Approve PR
-        if: ${{ github.actor == '3ware-release[bot]' && github.head_ref == 'trunk-io/update-trunk' }}
         uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:
           github-token: ${{ secrets.PR_APPROVAL_PAT }}


### PR DESCRIPTION
Tests run in #121 highlighted two problems:

1. The condition for the execution of the approval job should be set at the job level so the job is skipped if the conditions are not met. This was incorrectly set at the step level. This is confusing because it looks like the job has run in the pull request, when in fact the only step in the job has been (correctly) skipped.

2. When `enforce-all-checks` is triggered via the `pull_request_target` event it is not in the same context as the other checks. As a result it had completed before the other checks had - which defeats the point of this check. To overcome this, the `pull_request` trigger has been reintroduced with a conditional execution statement to run `enforce-all-checks` on `pull_request` events. 