### PR TITLE
fix(checks): Add ignore for auto-approve-pr check

### DIFF
--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -23,6 +23,9 @@ jobs:
         uses: poseidon/wait-for-status-checks@6988432d64ad3f9c2608db4ca16fded1b7d36ead # v0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # check run "auto-approve-pr" is completed with conclusion "cancelled" (unsuccessful) when skipped
+          # auto-approve-pr should run on the conclusion of enforce-all-checks, so checks should not check for auto-approve-pr
+          ignore: auto-approve-pr
 
   # Approve PR raised by 3ware-release[bot] to upgrade trunk on trunk branches
   # after all checks have passed.


### PR DESCRIPTION
`enforce-all-checks` failed previously because the conclusion of `auto-approve-pr` was reported as cancelled; `auto-approve-pr` is skipped due to the conditions.

`auto-approve-pr` should only run in certain conditions (see config) when `enforce-all-checks` has completed. Therefore we must excluded `auto-approve-pr` from being checked by enforce-all-checks.