### PR TITLE
ci(renovate): Use the vulnerability alert preset

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,13 +11,13 @@
             "release": "major"
           },
           {
-            "type": "refactor",
-            "release": "minor"
+            "release": "minor",
+            "type": "refactor"
           },
           {
-            "type": "chore",
+            "release": "patch",
             "scope": "deps",
-            "release": "patch"
+            "type": "chore"
           }
         ]
       }
@@ -29,25 +29,31 @@
         "presetConfig": {
           "types": [
             {
-              "type": "refactor",
+              "hidden": false,
               "section": "Enhancement",
-              "hidden": false
+              "type": "refactor"
             },
             {
-              "type": "feat",
+              "hidden": false,
               "section": "Features",
-              "hidden": false
+              "type": "feat"
             },
             {
-              "type": "fix",
+              "hidden": false,
               "section": "Bug Fixes",
-              "hidden": false
+              "type": "fix"
             },
             {
-              "type": "chore",
+              "hidden": false,
               "scope": "deps",
-              "section": "Chores",
-              "hidden": false
+              "section": "Security",
+              "type": "fix"
+            },
+            {
+              "hidden": false,
+              "scope": "deps",
+              "section": "Dependencies",
+              "type": "chore"
             }
           ]
         }
@@ -56,9 +62,9 @@
     [
       "@semantic-release/github",
       {
-        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version}",
         "labels": false,
-        "releasedLabels": false
+        "releasedLabels": false,
+        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version}"
       }
     ],
     [

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,13 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "commitMessageLowerCase": "never",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackageNames": [".*"]
+    }
+  ],
   "vulnerabilityAlerts": {
-    "schedule": [],
-    "dependencyDashboardApproval": false,
-    "minimumReleaseAge": null,
-    "rangeStrategy": "auto",
+    "addLabels": ["security"],
     "branchTopic": "{{{datasource}}}-{{{depNameSanitized}}}-vulnerability",
+    "commitMessagePrefix": "fix(deps): ",
+    "dependencyDashboardApproval": false,
+    "enabled": true,
+    "minimumReleaseAge": null,
     "prCreation": "immediate",
-    "vulnerabilityFixStrategy": "lowest",
-    "addLabels": ["security"]
+    "rangeStrategy": "auto",
+    "schedule": [],
+    "vulnerabilityFixStrategy": "lowest"
   }
 }

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -17,6 +17,7 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
+    - renovate@39.169.3
     - actionlint@1.7.7
     - checkov@3.2.358
     - git-diff-check


### PR DESCRIPTION
Renovate provides a preset configuration for vulnerability alerts which prevents pull requests being raised for other dependencies.

This preset has been added to the renovate config file, with some additional settings:

- Use upper case characters in pull requests
- Use `fix(deps):` as the commit messages prefix. Semantic release will use this prefix to add vulnerability alert fixes to the Security section of the changelog.