### PR TITLE
ci(renovate): Reduce commit message size

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "commitMessageExtra": "",
   "commitMessageLowerCase": "never",
   "extends": ["config:recommended"],
   "packageRules": [


### PR DESCRIPTION
The renovate commit message has to potential to exceed 72 characters. To try and overcome this I have set `commitMessageExtra` to `""` in the configuration file.

commitMessageExtra usually identifies the version of the update. This information is available in the pull request so can be left off the pull request title (commitMessage).