### PR TITLE
refactor(terraform-docs): Use tf-directory input throughout workflow 

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -76,7 +76,7 @@ jobs:
           echo "Please review the logs" >> $GITHUB_STEP_SUMMARY
 
       - name: Summary with document changes
-        if: ${{ steps.push-with-sig.conclusion == 'success' }}
+        if: ${{ steps.push-with-sig.conclusion == 'success' && steps.push-with-sig.outputs.commit-hash != ''}}
         run: |
           echo "### :white_check_mark: Terraform docs updated" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -64,8 +64,9 @@ jobs:
           branch: ${{ env.BRANCH }}
           file_pattern: "${{ inputs.tf-directory }}/**/${{ env.TF_DOCS_FILE }}"
 
+      # This step produces a job summary if the commit fails or if the documents are not updated
       - name: Summary with commit failure
-        if: ${{ failure() && steps.push-with-sig.outcome == 'failure' }}
+        if: ${{ (failure() && steps.push-with-sig.outcome == 'failure') || (success() && steps.push-with-sig.outputs.commit-hash == '') }}
         run: |
           echo "### :x: ${{ env.TF_DOCS_FILE }} not updated" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -59,10 +59,10 @@ jobs:
           GITHUB_TOKEN: ${{ steps.decrypt-token.outputs.temp-token }}
         uses: planetscale/ghcommit-action@c7915d6c18d5ce4eb42b0eff3f10a29fe0766e4c # v0.1.44
         with:
-          commit_message: "docs(terraform): Update ${{ env.TF_DOCS_FILE }}"
+          commit_message: "docs(${{ inputs.tf-directory }}): Update ${{ env.TF_DOCS_FILE }}"
           repo: ${{ github.repository }}
           branch: ${{ env.BRANCH }}
-          file_pattern: "terraform/**/${{ env.TF_DOCS_FILE }}"
+          file_pattern: "${{ inputs.tf-directory }}/**/${{ env.TF_DOCS_FILE }}"
 
       - name: Summary with commit failure
         if: ${{ failure() && steps.push-with-sig.outcome == 'failure' }}


### PR DESCRIPTION
The workflow job summaries were reporting that files has been successfully updated when they had not. This was because the step to generate the docs was using the input for `tf-directory` but the step to commit the changed files had `terraform` hardcoded. As a result files were being staged in a different directory and were not being committed. This has been resolved by changing the commit step to use the input for `tf-directory` as well.

Step summary conditional execution has also been improved to ensure the `failure` step runs if the commit step succeeds but the commit hash is empty. 