### PR TITLE
feat(trunk): Add `workflow_call` trigger

### DIFF
--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -41,4 +41,4 @@ jobs:
         uses: trunk-io/trunk-action/upgrade@8e4c812061ece3fa253bbfa5a80ee1caefa19eb1 # v1.22.9
         with:
           github-token: ${{ steps.decrypt-token.outputs.temp-token }}
-          prefix: "ci(trunk):"
+          prefix: "ci(trunk): "

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -2,6 +2,7 @@ name: Trunk Upgrade
 on:
   schedule:
     - cron: 0 1 * * 2
+  workflow_call: {}
   workflow_dispatch: {}
 
 permissions: {}


### PR DESCRIPTION
Enable reusability of the trunk upgrade workflow by adding the `workflow_call` trigger.