### PR TITLE
feat(checks): Add workflow_call event to wait-for-checks workflow

### DIFF
--- a/.github/workflows/delete-workflow-run.yaml
+++ b/.github/workflows/delete-workflow-run.yaml
@@ -2,7 +2,6 @@ name: Delete old workflow runs
 on:
   schedule:
     - cron: 0 0 1 * *
-  workflow_call: {}
 
 # Disable permissions for all available scopes
 permissions: {}

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -24,7 +24,6 @@ jobs:
     needs: [get-temp-token]
     env:
       TF_DOCS_FILE: README.md
-      # TODO: Define as an input, because calling workflow could use a different event type
       BRANCH: ${{ github.base_ref }}
     steps:
       - name: Decrypt the installation access token

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -27,6 +27,8 @@ jobs:
           # check run "auto-approve-pr" is completed with conclusion "cancelled" (unsuccessful) when skipped
           # auto-approve-pr should run on the conclusion of enforce-all-checks, so checks should not check for auto-approve-pr
           ignore: auto-approve-pr
+          # ignore any pattern before / enforce-all-checks
+          ignore_pattern: .*\/enforce-all-checks
 
   # Approve PR raised by 3ware-release[bot] to upgrade trunk on trunk branches
   # after all checks have passed.

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -27,8 +27,9 @@ jobs:
           # check run "auto-approve-pr" is completed with conclusion "cancelled" (unsuccessful) when skipped
           # auto-approve-pr should run on the conclusion of enforce-all-checks, so checks should not check for auto-approve-pr
           ignore: auto-approve-pr
-          # ignore any pattern before / enforce-all-checks
-          ignore_pattern: .*\/enforce-all-checks
+          # ignore any pattern before '/ enforce-all-checks' for calling workflows
+          # For example if the calling workflow job name is 'Checks' the path to ignore is 'Checks / enforce-all-checks'
+          ignore_pattern: .*\/ enforce-all-checks
 
   # Approve PR raised by 3ware-release[bot] to upgrade trunk on trunk branches
   # after all checks have passed.

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
     branches: [main]
+  workflow_call: {}
 
 # Disable permissions for all available scopes
 permissions: {}


### PR DESCRIPTION
`workflow_call` trigger added to checks workflow to allow reusability.

To ensure that a calling workflow's `enforce-all-checks` is ignored a regex `ignore_pattern` has been added to ignore any prefix of `enforce-all-checks`. For example if the calling workflow job name is `Checks` then `Checks / enforce-all-checks` should be ignored. 