### PR TITLE
ci(renovate): Switch to security:only-security-updates preset

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -2,23 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "commitMessageExtra": "",
   "commitMessageLowerCase": "never",
-  "extends": ["config:recommended"],
-  "packageRules": [
-    {
-      "enabled": false,
-      "matchPackageNames": [".*"]
-    }
-  ],
+  "extends": ["security:only-security-updates"],
   "vulnerabilityAlerts": {
     "addLabels": ["security"],
-    "branchTopic": "{{{datasource}}}-{{{depNameSanitized}}}-vulnerability",
     "commitMessagePrefix": "fix(deps): ",
-    "dependencyDashboardApproval": false,
-    "enabled": true,
-    "minimumReleaseAge": null,
-    "prCreation": "immediate",
-    "rangeStrategy": "auto",
-    "schedule": [],
-    "vulnerabilityFixStrategy": "lowest"
+    "rangeStrategy": "auto"
   }
 }


### PR DESCRIPTION
Renovate should only raise PRs for vulnerability alerts. The configuration file has been updated to use to preset provided by renovate with a couple of adjustments to ensure the commit message isn't too long, is sentence case and has the correct prefix for the release workflow to match.

Resolves #148 