### PR TITLE
feat(pr-title): Add empty commit step

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Delete PR comment on resolution
         # Delete comment if the error message is null or the PR title is the correct length
-        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null }}
+        if: ${{ steps.validate-pr-title.outputs.error_message == null }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: pr-title-error
@@ -127,7 +127,7 @@ jobs:
 
       - name: Summary with valid title
         # A length check is not required here because the validate-pr-title step will only run if the title is less than or equal to the max length
-        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null }}
+        if: ${{ steps.validate-pr-title.outputs.error_message == null }}
         run: |
           echo "### :white_check_mark: Pull Request title is valid" >> $GITHUB_STEP_SUMMARY
           echo "The pull request title conforms to the conventional commit specification." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -126,6 +126,10 @@ jobs:
           header: pr-title-error
           delete: true
 
+      - name: dump pull request event details
+        run: |
+          echo '${{ toJson(github.event) }}'
+
       - name: Trigger checks when title is valid
         if: ${{ github.event.pull_request.title.changes.from }}
         run: |

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -130,8 +130,9 @@ jobs:
         run: |
           echo '${{ toJson(github.event) }}'
 
-      - name: Trigger checks when title is valid
-        if: ${{ github.event.pull_request.changes.title.from }}
+      # Trigger checks with empty commit when PR title is edited to resolve validation failure
+      - name: Trigger checks with empty commit
+        if: ${{ github.event.pull_request.action == 'edited' && github.event.pull_request.changes.title.from != null }}
         run: |
           echo "Title changed from: ${{ github.event.pull_request.changes.title.from }}"
 

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -2,7 +2,7 @@ name: Validate PR title
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened]
     branches: [main]
   workflow_call: {}
 
@@ -120,10 +120,16 @@ jobs:
       - name: Delete PR comment on resolution
         # Delete comment if the error message is null or the PR title is the correct length
         if: ${{ steps.validate-pr-title.outputs.error_message == null }}
+        id: delete-comment
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: pr-title-error
           delete: true
+
+      - name: Trigger checks when title is valid
+        if: ${{ github.event.pull_request.title.changes.from }}
+        run: |
+          echo "Title changed from: ${{ github.event.pull_request.title.changes.from }}"
 
       - name: Summary with valid title
         # A length check is not required here because the validate-pr-title step will only run if the title is less than or equal to the max length

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -128,7 +128,8 @@ jobs:
 
       - name: dump pull request event details
         run: |
-          echo '${{ toJson(github.event) }}'
+          echo "PR action: ${{ github.event.pull_request.action }}"
+          echo "PR changes: ${{ toJSON(github.event.pull_request.changes) }}"
 
       # Trigger checks with empty commit when PR title is edited to resolve validation failure
       - name: Trigger checks with empty commit

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -131,9 +131,9 @@ jobs:
           echo '${{ toJson(github.event) }}'
 
       - name: Trigger checks when title is valid
-        if: ${{ github.event.pull_request.title.changes.from }}
+        if: ${{ github.event.pull_request.changes.title.from }}
         run: |
-          echo "Title changed from: ${{ github.event.pull_request.title.changes.from }}"
+          echo "Title changed from: ${{ github.event.pull_request.changes.title.from }}"
 
       - name: Summary with valid title
         # A length check is not required here because the validate-pr-title step will only run if the title is less than or equal to the max length

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -2,7 +2,7 @@ name: Checks
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
     branches: [main]
   workflow_call: {}
 
@@ -34,6 +34,7 @@ jobs:
   # Approve PR raised by 3ware-release[bot] to upgrade trunk on trunk branches
   # after all checks have passed.
   auto-approve-pr:
+    # TODO: Add terraform app to actor, maybe project/** to branch as well
     if: ${{ github.actor == '3ware-release[bot]' && github.head_ref == 'trunk-io/update-trunk' }}
     needs: [enforce-all-checks]
     runs-on: ubuntu-latest


### PR DESCRIPTION
The required check (enforce-all-checks) will fail if the PR title is invalid - as expected. 

enforce-all-checks polls the check api for the most recent commit in the PR. Fixing the PR title does not generate a new commit which means re-running the failed checks workflow still results in failing - because it is polling the previous commit.

In this PR a step will be added to push an empty commit to trigger the checks workflow on a new commit where the PR title check has succeeded.

edit to trigger context output debug