### PR TITLE
fix(pr-title): Remove unecessary `if always` conditions

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Delete PR comment on resolution
         # Delete comment if the error message is null or the PR title is the correct length
-        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null }}
+        if: ${{ steps.validate-pr-title.outputs.error_message == null }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: pr-title-error
@@ -127,7 +127,7 @@ jobs:
 
       - name: Summary with valid title
         # A length check is not required here because the validate-pr-title step will only run if the title is less than or equal to the max length
-        if: ${{ always() && steps.validate-pr-title.outputs.error_message == null }}
+        if: ${{ steps.validate-pr-title.outputs.error_message == null }}
         run: |
           echo "### :white_check_mark: Pull Request title is valid" >> $GITHUB_STEP_SUMMARY
           echo "The pull request title conforms to the conventional commit specification." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -2,7 +2,7 @@ name: Validate PR title
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened]
     branches: [main]
   workflow_call: {}
 

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -2,7 +2,7 @@ name: Checks
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
     branches: [main]
   workflow_call: {}
 
@@ -34,6 +34,7 @@ jobs:
   # Approve PR raised by 3ware-release[bot] to upgrade trunk on trunk branches
   # after all checks have passed.
   auto-approve-pr:
+    # TODO: Add terraform app to actor, maybe project/** to branch as well
     if: ${{ github.actor == '3ware-release[bot]' && github.head_ref == 'trunk-io/update-trunk' }}
     needs: [enforce-all-checks]
     runs-on: ubuntu-latest


### PR DESCRIPTION
`if: always()` is not required in steps that run when the preceding step has succeeded.

They only need to be used when the preceding step has failed. For example, when the PR title is invalid (and the step fails) we want the PR comment step to run anyway.