### PR TITLE
ci(pr-check): Use `pull_request_target` event

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,6 +1,6 @@
 name: PR Check
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 # Disable permissions for all available scopes


### PR DESCRIPTION
PR check adds comments to pull requests. Using `pull_request_target` for actions that comment on pull requests is recommended. 
