### PR TITLE
refactor(dep-review): Enable pr comment summary

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -6,7 +6,7 @@
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: Dependency Review
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
     branches: [main]
 
@@ -21,6 +21,7 @@ jobs:
   dependency-review:
     permissions:
       contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -28,3 +29,6 @@ jobs:
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Dependency Review
         uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0
+        with:
+          comment-summary-in-pr: always
+          fail-on-severity: high


### PR DESCRIPTION
To safely enable the `comment-summary-in-pr` feature, the trigger has been updated to `pull_request_target` because now the token has write permissions to the pr.