### PR TITLE
ci(pr-check): Disable auto-approve job

### DIFF
--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -31,7 +31,7 @@ jobs:
   # This job will only run if enforce-all-checks job has passed successfully on pull requests. This workflow could be called by
   # a merge_group event: in this case it should not run
   auto-approve-pr:
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.labels[0].name == 'auto-approve' }}
+    if: ${{ github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'auto-approve') }}
     needs: [enforce-all-checks]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -31,10 +31,7 @@ jobs:
   # This job will only run if enforce-all-checks job has passed successfully on pull requests. This workflow could be called by
   # a merge_group event: in this case it should not run
   auto-approve-pr:
-    if: |
-      github.event_name == 'pull_request' &&
-      ( github.actor == '3ware-release[bot]' && github.head_ref == 'trunk-io/update-trunk') ||
-      ( github.actor == '3ware-terraform[bot]' && startsWith(github.head_ref, 'project/'))
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.labels[0].name == 'auto-approve' }}
     needs: [enforce-all-checks]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -30,14 +30,14 @@ jobs:
   # Approve PR raised by 3ware-release[bot] to upgrade trunk on trunk branches or by 3ware-terraform[bot] on project branches
   # This job will only run if enforce-all-checks job has passed successfully on pull requests. This workflow could be called by
   # a merge_group event: in this case it should not run
-  auto-approve-pr:
-    if: ${{ github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'auto-approve') }}
-    needs: [enforce-all-checks]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Auto Approve PR
-        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
-        with:
-          github-token: ${{ secrets.PR_APPROVAL_PAT }}
-          review-message: All checks passed. Auto Approved.
+  # auto-approve-pr:
+  #   if: ${{ github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'auto-approve') }}
+  #   needs: [enforce-all-checks]
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 5
+  #   steps:
+  #     - name: Auto Approve PR
+  #       uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+  #       with:
+  #         github-token: ${{ secrets.PR_APPROVAL_PAT }}
+  #         review-message: All checks passed. Auto Approved.


### PR DESCRIPTION
Needs to run as a separate job in downstream workflows to read labels.