### PR TITLE
feat(iac-deploy): Create reusable workflow for iac deployments

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -16,6 +16,7 @@
         "delete-run",
         "dep-review",
         "get-token",
+        "iac-deploy",
         "pr-check",
         "pr-title",
         "ossf",

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -94,7 +94,6 @@ jobs:
         run: mkdir --parents ${{ env.TF_PLUGIN_CACHE_DIR }}
 
       - name: Cache TF plugin directory
-        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
@@ -119,6 +118,7 @@ jobs:
           tool: tofu
 
       - name: Create TFLint cache directory
+        if: ${{ github.event_name == 'pull_request' }}
         run: mkdir --parents ${{ env.TFLINT_PLUGIN_DIR }}
 
       - name: Cache TFLint plugin directory

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -59,6 +59,7 @@ jobs:
       id-token: write # Require for OIDC.
       pull-requests: write # Required to add comment and label.
     env:
+      TFLINT_PLUGIN_DIR: ${{ github.workspace }}/.tflint.d/plugins
       TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
       WORKING_DIR: ${{ needs.targets.outputs.targets }}
@@ -89,7 +90,7 @@ jobs:
             format('plan-{0}', inputs.environment)
             }}
 
-      - name: Create cache directory
+      - name: Create TF cache directory
         run: mkdir --parents ${{ env.TF_PLUGIN_CACHE_DIR }}
 
       - name: Cache TF plugin directory
@@ -117,11 +118,14 @@ jobs:
           label-pr: false
           tool: tofu
 
+      - name: Create TFLint cache directory
+        run: mkdir --parents ${{ env.TFLINT_PLUGIN_DIR }}
+
       - name: Cache TFLint plugin directory
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: .trunk/plugins/
+          path: ${{ env.TFLINT_PLUGIN_DIR }}
           key: cache-tflint-${{ runner.os }}-${{ github.repository }}-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}
 
       # Install TFLint; required to download plugins

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -55,6 +55,7 @@ jobs:
       id-token: write # Require for OIDC.
       pull-requests: write # Required to add comment and label.
     env:
+      TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
       WORKING_DIR: ${{ needs.targets.outputs.targets }}
     runs-on: ubuntu-latest
@@ -84,12 +85,19 @@ jobs:
             format('plan-{0}', inputs.environment)
             }}
 
-      - name: Setup IAC tool
+      - name: Cache TF plugin directory
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ env.TF_PLUGIN_CACHE_DIR }}
+          key: cache-tf-${{ runner.os }}-${{ github.repository }}-${{ hashFiles('${{ env.WORKING_DIR }}/.terraform.lock.hcl') }}
+
+      - name: Setup TF tool
         uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668b1aee8f716 # v1.0.5
         with:
           tofu_wrapper: false
 
-      - name: IAC Fmt + Init + Validate
+      - name: TF Fmt + Init + Validate
         if: ${{ github.event_name == 'pull_request' }}
         id: tf
         uses: op5dev/tf-via-pr@f455e10e6e83d28f53f505a2d8242433a17536f3 # v13.0.0
@@ -107,7 +115,7 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .trunk/plugins/
-          key: ${{ runner.os }}-${{ github.repository }}-tflint-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}
+          key: cache-tflint-${{ runner.os }}-${{ github.repository }}-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}
 
       # Install TFLint; required to download plugins
       - name: Install TFLint

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -85,6 +85,9 @@ jobs:
             format('plan-{0}', inputs.environment)
             }}
 
+      - name: Create cache directory
+        run: mkdir --parents ${{ env.TF_PLUGIN_CACHE_DIR }}
+
       - name: Cache TF plugin directory
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -76,8 +76,8 @@ jobs:
           mask-aws-account-id: true
           role-to-assume: >-
             ${{ github.event_name == 'merge_group' &&
-            secrets[format('AWS_IAM_{0}_OIDC_AA_ROLE_ARN', inputs.environment)] ||
-            secrets[format('AWS_IAM_{0}_OIDC_RO_ROLE_ARN', inputs.environment)]
+            secrets[format('AWS_OIDC_AA_{0}_ROLE_ARN', inputs.environment)] ||
+            secrets[format('AWS_OIDC_RO_{0}_ROLE_ARN', inputs.environment)]
             }}
           role-session-name: >-
             iac-deployment-${{ github.event_name == 'merge_group' &&

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -1,0 +1,155 @@
+name: IAC Deploy
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: The deployment environment
+        type: string
+        required: true
+
+# Disable permissions for all available scopes
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}-${{ inputs.environment }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  targets:
+    name: IAC Targets
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.directories.outputs.all_changed_files }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check changed directories
+        id: directories
+        uses: tj-actions/changed-files@c3a1bb2c992d77180ae65be6ae6c166cf40f857c # v45.0.3
+        with:
+          dir_names: true
+          dir_names_max_depth: 3
+          # TODO: Use inputs for these
+          files: iac/environments/**
+          files_ignore: iac/environments/glb/**
+
+  iac-deploy:
+    needs: [targets]
+    if: ${{ needs.targets.outputs.targets != '[]' }}
+    name: IAC Deploy
+    permissions:
+      actions: read # Required to identify workflow run.
+      checks: write # Required to add status summary.
+      contents: read # Required to checkout repository.
+      id-token: write # Require for OIDC.
+      pull-requests: write # Required to add comment and label.
+    env:
+      TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
+      WORKING_DIR: ${{ needs.targets.outputs.targets }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      # AWS Credentials required for tflint deep check
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          # TODO: Use an input for the region
+          aws-region: eu-west-2
+          mask-aws-account-id: true
+          role-to-assume: >-
+            ${{ github.event_name == 'merge_group' &&
+            secrets[format('AWS_IAM_{0}_OIDC_AA_ROLE_ARN', inputs.environment)] ||
+            secrets[format('AWS_IAM_{0}_OIDC_RO_ROLE_ARN', inputs.environment)]
+            }}
+          role-session-name: >-
+            iac-deployment-${{ github.event_name == 'merge_group' &&
+            format('apply-{0}', inputs.environment) ||
+            format('plan-{0}', inputs.environment)
+            }}
+
+      - name: Terraform Fmt + Init + Validate
+        if: ${{ github.event_name == 'pull_request' }}
+        id: tf
+        uses: op5dev/tf-via-pr@f455e10e6e83d28f53f505a2d8242433a17536f3 # v13.0.0
+        with:
+          working-directory: ${{ env.WORKING_DIR }}
+          command: init
+          arg-lock: false
+          format: true
+          validate: true
+          label-pr: false
+
+      - name: Cache TFLint plugin directory
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: .trunk/plugins/
+          key: ${{ runner.os }}-${{ github.repository }}-tflint-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}
+
+      # Install TFLint; required to download plugins
+      - name: Install TFLint
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: terraform-linters/setup-tflint@15ef44638cb215296e7ba9e7a41f20b5b06f4784 # v4.0.0
+        with:
+          tflint_wrapper: true
+
+      # Run TFLint using the configuration file in the trunk directory
+      - name: Run TFLint
+        if: ${{ github.event_name == 'pull_request' }}
+        id: tflint
+        run: |
+          tflint --chdir=${{ env.WORKING_DIR }} --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --init
+          tflint --chdir=${{ env.WORKING_DIR }} --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --format compact
+        continue-on-error: true
+
+      # Add PR comment then exit workflow if TFLint detects a violation
+      - name: Add PR comment on TFLint error
+        if: ${{ steps.tflint.outputs.exitcode != 0 }}
+        env:
+          GH_TOKEN: ${{ github.token }} # https://cli.github.com/manual/gh_auth_login
+        run: |
+          # Compose TFLint output.
+          tflint="
+          <details><summary>❌ TFLint error.</summary>
+
+          \`\`\`hcl
+          ${{ steps.tflint.outputs.stderr || steps.tflint.outputs.stdout }}
+          \`\`\`
+          </details>"
+
+          # Get body of PR comment from tf step output.
+          comment=$(gh api /repos/{owner}/{repo}/issues/comments/${{ steps.tf.outputs.comment-id }} --method GET --jq '.body')
+
+          # Replace placeholder with TFLint output.
+          comment="${comment//<!-- placeholder-2 -->/$tflint}"
+
+          # Update PR comment combined with TFLint output.
+          gh api /repos/{owner}/{repo}/issues/comments/${{ steps.tf.outputs.comment-id }} --method PATCH --field body="$comment"
+
+          # Exit workflow due to TFLint error.
+          exit 1
+
+      - name: IAC Deployment ${{ format('{0}', github.event_name == 'merge_group' && 'Apply' || 'Plan') }}
+        uses: op5dev/tf-via-pr@f455e10e6e83d28f53f505a2d8242433a17536f3 # v13.0.0
+        with:
+          working-directory: ${{ env.WORKING_DIR }}
+          command: ${{ github.event_name == 'merge_group' && 'apply' || 'plan' }}
+          arg-lock: ${{ github.event_name == 'merge_group' }}
+          plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -84,7 +84,12 @@ jobs:
             format('plan-{0}', inputs.environment)
             }}
 
-      - name: Terraform Fmt + Init + Validate
+      - name: Setup IAC tool
+        uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668b1aee8f716 # v1.0.5
+        with:
+          tofu_wrapper: false
+
+      - name: IAC Fmt + Init + Validate
         if: ${{ github.event_name == 'pull_request' }}
         id: tf
         uses: op5dev/tf-via-pr@f455e10e6e83d28f53f505a2d8242433a17536f3 # v13.0.0
@@ -95,6 +100,7 @@ jobs:
           format: true
           validate: true
           label-pr: false
+          tool: tofu
 
       - name: Cache TFLint plugin directory
         if: ${{ github.event_name == 'pull_request' }}
@@ -153,3 +159,4 @@ jobs:
           command: ${{ github.event_name == 'merge_group' && 'apply' || 'plan' }}
           arg-lock: ${{ github.event_name == 'merge_group' }}
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+          tool: tofu

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -44,13 +44,13 @@ jobs:
           files: iac/environments/**
           files_ignore: iac/environments/glb/**
 
-      - name: Echo some stuff
+      - name: Print Outputs
         run: |
-          echo "Changed directories: ${{ steps.directories.outputs.all_changed_files }}"
+          echo "Change directories: ${{ steps.directories.outputs.all_changed_files }}"
 
   iac-deploy:
     needs: [targets]
-    if: ${{ needs.targets.outputs.targets != '[]' }}
+    if: ${{ needs.targets.outputs.targets != '[]' && needs.targets.outputs.targets != '' }}
     name: IAC Deploy
     permissions:
       actions: read # Required to identify workflow run.

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Cache TFLint plugin directory
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .trunk/plugins/
           key: ${{ runner.os }}-${{ github.repository }}-tflint-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-          key: cache-tf-${{ runner.os }}-${{ github.repository }}-${{ hashFiles('${{ env.WORKING_DIR }}/.terraform.lock.hcl') }}
+          key: cache-tf-${{ runner.os }}-${{ github.repository }}-${{ hashFiles(format('{0}/.terraform.lock.hcl', env.WORKING_DIR)) }}
 
       - name: Setup TF tool
         uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668b1aee8f716 # v1.0.5

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -44,6 +44,10 @@ jobs:
           files: iac/environments/**
           files_ignore: iac/environments/glb/**
 
+      - name: Echo some stuff
+        run: |
+          echo "Changed directories: ${{ steps.directories.outputs.all_changed_files }}"
+
   iac-deploy:
     needs: [targets]
     if: ${{ needs.targets.outputs.targets != '[]' }}


### PR DESCRIPTION
The purpose of this workflow is to create a plan comment in the pull request and apply, via merge queue on merge.

~~Successful applies will trigger code promotion, where the workflow can be called again to apply to a different environment.~~

The environment is provided via an input.