### PR TITLE
fix(pr-title): Set cancel-in-progress to false

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -8,7 +8,10 @@ permissions: {}
 
 concurrency:
   group: pr-title-${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
+  # Do no cancel in progress jobs. When a PR is synchronized and edited in quick
+  # succession, for example by Renovate pushing an update and changing the title,
+  # the checks workflow fails because it sees this job has been cancelled.
 
 defaults:
   run:

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "commitMessageExtra": "",
   "commitMessageLowerCase": "never",
   "extends": [
     "helpers:pinGitHubActionDigests",


### PR DESCRIPTION
`cancel-in-progress: true` is causing checks to fail in scenarios where a PR is synchronized and edited in quick succession. For example: a renovate PR will push a new update (synch event) and then update the title (edit event). The checks job will poll the checks api for the commit of the sync event where the pr-title job has been cancelled by the job created by the edit event. In this case PRs cannot be merged because the required check 'Checks / enforce-all-checks' has failed. 