### PR TITLE
feat(iac-deploy): Add TF_VAR environment variable for environment

### DIFF
--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -174,8 +174,9 @@ jobs:
       - name: IAC Deployment ${{ format('{0}', github.event_name == 'merge_group' && 'Apply' || 'Plan') }}
         uses: op5dev/tf-via-pr@f455e10e6e83d28f53f505a2d8242433a17536f3 # v13.0.0
         with:
+          tool: tofu
           working-directory: ${{ env.WORKING_DIR }}
           command: ${{ github.event_name == 'merge_group' && 'apply' || 'plan' }}
           arg-lock: ${{ github.event_name == 'merge_group' }}
+          arg-var: ${{ inputs.environment }}
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
-          tool: tofu

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -60,6 +60,7 @@ jobs:
       pull-requests: write # Required to add comment and label.
     env:
       TFLINT_PLUGIN_DIR: ${{ github.workspace }}/.tflint.d/plugins
+      TF_VAR_aws_environment: ${{ inputs.environment }}
       TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
       WORKING_DIR: ${{ needs.targets.outputs.targets }}
@@ -178,5 +179,4 @@ jobs:
           working-directory: ${{ env.WORKING_DIR }}
           command: ${{ github.event_name == 'merge_group' && 'apply' || 'plan' }}
           arg-lock: ${{ github.event_name == 'merge_group' }}
-          arg-var: "aws_environment=${{ inputs.environment }}"
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -178,5 +178,5 @@ jobs:
           working-directory: ${{ env.WORKING_DIR }}
           command: ${{ github.event_name == 'merge_group' && 'apply' || 'plan' }}
           arg-lock: ${{ github.event_name == 'merge_group' }}
-          arg-var: aws_environment=${{ inputs.environment }}
+          arg-var: "aws_environment=${{ inputs.environment }}"
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -24,6 +24,9 @@ jobs:
     name: IAC Targets
     permissions:
       contents: read
+    env:
+      # Maps the environment name to the directory name
+      ENVIRONMENT_MAP: '{"development":"dev","testing":"tst","productions":"prd","staging":"stg"}'
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.directories.outputs.all_changed_files }}
@@ -40,13 +43,8 @@ jobs:
         with:
           dir_names: true
           dir_names_max_depth: 3
-          # TODO: Use inputs for these
-          files: iac/environments/**
+          files: iac/environments/${{ env.ENVIRONMENT_MAP[inputs.environment] }}/**
           files_ignore: iac/environments/glb/**
-
-      - name: Print Outputs
-        run: |
-          echo "Change directories: ${{ steps.directories.outputs.all_changed_files }}"
 
   iac-deploy:
     needs: [targets]

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -178,5 +178,5 @@ jobs:
           working-directory: ${{ env.WORKING_DIR }}
           command: ${{ github.event_name == 'merge_group' && 'apply' || 'plan' }}
           arg-lock: ${{ github.event_name == 'merge_group' }}
-          arg-var: ${{ inputs.environment }}
+          arg-var: aws_environment=${{ inputs.environment }}
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -3,6 +3,10 @@ name: IAC Deploy
 on:
   workflow_call:
     inputs:
+      aws-region:
+        description: The AWS region to deploy to
+        type: string
+        required: true
       environment:
         description: The deployment environment
         type: string
@@ -43,7 +47,7 @@ jobs:
         with:
           dir_names: true
           dir_names_max_depth: 3
-          files: iac/environments/${{ env.ENVIRONMENT_MAP[inputs.environment] }}/**
+          files: iac/environments/${{ fromJSON(env.ENVIRONMENT_MAP)[inputs.environment] }}/**
           files_ignore: iac/environments/glb/**
 
   iac-deploy:
@@ -75,8 +79,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          # TODO: Use an input for the region
-          aws-region: eu-west-2
+          aws-region: ${{ inputs.aws-region}}
           mask-aws-account-id: true
           role-to-assume: >-
             ${{ github.event_name == 'merge_group' &&


### PR DESCRIPTION
The environment should not be hardcoded or specified in a TF_VARS file to allow for greater flexibility. override.tf files can be used for local testing prior to pushing to CI which can contain a "sandbox" provider and backend configuration. The "sandbox" environment can passed as a CLI argument or environment variable. In CI the actual deployment environment is provided as an input. If it was present in a TF_VARS file, it would talke precedence over the locally specified environment. To overcome this, the environment, passed as an input, is used to set the TF_VAR_aws_environment value in CI. 