### PR TITLE
fix(checks): Add event action to concurrency group name

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: dep-review-${{ github.workflow }}-${{ github.head_ref }}
+  group: dep-review-${{ github.workflow }}-${{ github.event.action }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -7,11 +7,11 @@ on:
 permissions: {}
 
 concurrency:
-  group: pr-title-${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: false
-  # Do no cancel in progress jobs. When a PR is synchronized and edited in quick
-  # succession, for example by Renovate pushing an update and changing the title,
-  # the checks workflow fails because it sees this job has been cancelled.
+  # Add the event type to the concurrency group name
+  # For example: to ensure unique events for edited and synchronized events
+  # Renovate PRs are often edited and synchronized in quick succession
+  group: pr-title-${{ github.workflow }}-${{ github.event.action }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 defaults:
   run:


### PR DESCRIPTION
Downstream workflows are being cancelled when renovate rebases as PR. This occurs because renovate will often update the title (edited event) and then force push any changes (synchronize event). Workflows triggered by edited events are being cancelled by workflows triggered by synchronize events because the concurrency group names are the same. Adding `github.event.action` to the concurrency group name should ensure they are unique for different events.