### PR TITLE
feat(iac-deploy): Add capability to run on TFLint config updates

### DIFF
--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -76,7 +76,7 @@ jobs:
       # TODO: test as me: chris3ware. Restore 'renovate[bot]' after test
       WORKING_DIR: >-
         ${{ (github.actor == 'chris3ware' && needs.targets.outputs.targets == 'iac') &&
-        'iac/environments/development' ||
+        'iac/environments/dev' ||
         needs.targets.outputs.targets }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -73,9 +73,8 @@ jobs:
       TF_VAR_aws_environment: ${{ inputs.environment }}
       TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
-      # TODO: test as me: chris3ware. Restore 'renovate[bot]' after test
       WORKING_DIR: >-
-        ${{ (github.actor == 'chris3ware' && needs.targets.outputs.targets == 'iac') &&
+        ${{ (github.actor == 'renovate[bot]' && needs.targets.outputs.targets == 'iac') &&
         'iac/environments/dev' ||
         needs.targets.outputs.targets }}
     runs-on: ubuntu-latest

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -68,8 +68,8 @@ jobs:
       TF_VAR_aws_environment: ${{ inputs.environment }}
       TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
+      # TODO: test as me: chris3ware. Restore 'renovate[bot]' after test
       WORKING_DIR: >-
-        # TODO: test as me: chris3ware. Restore 'renovate[bot]' after test
         ${{ (github.actor == 'chris3ware' && needs.targets.outputs.targets == 'iac/.tflint.hcl') &&
         'iac/environments/development' ||
         needs.targets.outputs.targets }}

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -69,7 +69,8 @@ jobs:
       TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
       WORKING_DIR: >-
-        ${{ (github.actor == 'renovate[bot]' && needs.targets.outputs.targets == 'iac/.tflint.hcl') &&
+        # TODO: test as me: chris3ware. Restore 'renovate[bot]' after test
+        ${{ (github.actor == 'chris3ware' && needs.targets.outputs.targets == 'iac/.tflint.hcl') &&
         'iac/environments/development' ||
         needs.targets.outputs.targets }}
     runs-on: ubuntu-latest

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -52,6 +52,11 @@ jobs:
             iac/.tflint.hcl
           files_ignore: iac/environments/glb/**
 
+      - name: Echo outputs
+        run: |
+          echo ${{ steps.directories.outputs.all_changed_files }}"
+          echo ${{ github.actor }}
+
   iac-deploy:
     needs: [targets]
     if: ${{ needs.targets.outputs.targets != '[]' && needs.targets.outputs.targets != '' }}

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Echo outputs
         run: |
-          echo ${{ steps.directories.outputs.all_changed_files }}"
+          echo ${{ steps.directories.outputs.all_changed_files }}
           echo ${{ github.actor }}
 
   iac-deploy:
@@ -75,7 +75,7 @@ jobs:
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
       # TODO: test as me: chris3ware. Restore 'renovate[bot]' after test
       WORKING_DIR: >-
-        ${{ (github.actor == 'chris3ware' && needs.targets.outputs.targets == 'iac/.tflint.hcl') &&
+        ${{ (github.actor == 'chris3ware' && needs.targets.outputs.targets == 'iac') &&
         'iac/environments/development' ||
         needs.targets.outputs.targets }}
     runs-on: ubuntu-latest

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -47,7 +47,9 @@ jobs:
         with:
           dir_names: true
           dir_names_max_depth: 3
-          files: iac/environments/${{ fromJSON(env.ENVIRONMENT_MAP)[inputs.environment] }}/**
+          files: |
+            iac/environments/${{ fromJSON(env.ENVIRONMENT_MAP)[inputs.environment] }}/**
+            iac/.tflint.hcl
           files_ignore: iac/environments/glb/**
 
   iac-deploy:
@@ -61,6 +63,7 @@ jobs:
       id-token: write # Require for OIDC.
       pull-requests: write # Required to add comment and label.
     env:
+      TFLINT_CONFIG_FILE: ${{ github.workspace }}/iac/.tflint.hcl
       TFLINT_PLUGIN_DIR: ${{ github.workspace }}/.tflint.d/plugins
       TF_VAR_aws_environment: ${{ inputs.environment }}
       TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
@@ -128,7 +131,7 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ${{ env.TFLINT_PLUGIN_DIR }}
-          key: cache-tflint-${{ runner.os }}-${{ github.repository }}-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}
+          key: cache-tflint-${{ runner.os }}-${{ github.repository }}-${{ hashFiles('iac/.tflint.hcl') }}
 
       # Install TFLint; required to download plugins
       - name: Install TFLint
@@ -142,8 +145,8 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         id: tflint
         run: |
-          tflint --chdir=${{ env.WORKING_DIR }} --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --init
-          tflint --chdir=${{ env.WORKING_DIR }} --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --format compact
+          tflint --chdir=${{ env.WORKING_DIR }} --config=${{ env.TFLINT_CONFIG_FILE }} --init
+          tflint --chdir=${{ env.WORKING_DIR }} --config=${{ env.TFLINT_CONFIG_FILE }} --format compact
         continue-on-error: true
 
       # Add PR comment then exit workflow if TFLint detects a violation

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -23,9 +23,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  TFLINT_CONFIG_FILE: ${{ github.workspace }}/iac/.tflint.hcl
-
 jobs:
   targets:
     name: IAC Targets
@@ -52,7 +49,7 @@ jobs:
           dir_names_max_depth: 3
           files: |
             iac/environments/${{ fromJSON(env.ENVIRONMENT_MAP)[inputs.environment] }}/**
-            ${{ env.TFLINT_CONFIG_FILE }}
+            iac/.tflint.hcl
           files_ignore: iac/environments/glb/**
 
   iac-deploy:
@@ -66,6 +63,7 @@ jobs:
       id-token: write # Require for OIDC.
       pull-requests: write # Required to add comment and label.
     env:
+      TFLINT_CONFIG_FILE: ${{ github.workspace }}/iac/.tflint.hcl
       TFLINT_PLUGIN_DIR: ${{ github.workspace }}/.tflint.d/plugins
       TF_VAR_aws_environment: ${{ inputs.environment }}
       TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -23,6 +23,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  TFLINT_CONFIG_FILE: ${{ github.workspace }}/iac/.tflint.hcl
+
 jobs:
   targets:
     name: IAC Targets
@@ -49,7 +52,7 @@ jobs:
           dir_names_max_depth: 3
           files: |
             iac/environments/${{ fromJSON(env.ENVIRONMENT_MAP)[inputs.environment] }}/**
-            iac/.tflint.hcl
+            ${{ env.TFLINT_CONFIG_FILE }}
           files_ignore: iac/environments/glb/**
 
   iac-deploy:
@@ -63,12 +66,14 @@ jobs:
       id-token: write # Require for OIDC.
       pull-requests: write # Required to add comment and label.
     env:
-      TFLINT_CONFIG_FILE: ${{ github.workspace }}/iac/.tflint.hcl
       TFLINT_PLUGIN_DIR: ${{ github.workspace }}/.tflint.d/plugins
       TF_VAR_aws_environment: ${{ inputs.environment }}
       TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
-      WORKING_DIR: ${{ needs.targets.outputs.targets }}
+      WORKING_DIR: >-
+        ${{ (github.actor == 'renovate[bot]' && needs.targets.outputs.targets == 'iac/.tflint.hcl') &&
+        'iac/environments/development' ||
+        needs.targets.outputs.targets }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
 


### PR DESCRIPTION
iac-deploy should run when renovate makes updates to the TFLint configuration file. 

A ternary operator has been added to the `WORKING_DIR` environment variable so that:

- If the triggering actor is `renovate[bot]` and the path is `iac`, then `WORKING_DIR` should be set to the `dev` folder
- Otherwise, `WORKING_DIR` should be set to the output of the `targets` job

`tflint.hcl` resides in the `iac` directory. When renovate makes changes to it `iac` will be returned by the targets job. This location does not contain any terraform files so, because we want to test the change in the development environment, we set the working directory to `iac/dev`.

We do this so that we do not have duplicate `.tflint.hcl` files in every directory.