### PR TITLE
fix(checks): Add expression to allow renovate workflow run concurrency

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -15,8 +15,8 @@ on:
 permissions: {}
 
 concurrency:
-  group: dep-review-${{ github.workflow }}-${{ github.event.action }}-${{ github.head_ref }}
-  cancel-in-progress: true
+  group: dep-review-${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.actor == 'renovate[bot]' && false || true }}
 
 jobs:
   dependency-review:

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -7,11 +7,8 @@ on:
 permissions: {}
 
 concurrency:
-  # Add the event type to the concurrency group name
-  # For example: to ensure unique events for edited and synchronized events
-  # Renovate PRs are often edited and synchronized in quick succession
-  group: pr-title-${{ github.workflow }}-${{ github.event.action }}-${{ github.head_ref }}
-  cancel-in-progress: true
+  group: pr-title-${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.actor == 'renovate[bot]' && false || true }}
 
 defaults:
   run:

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -8,7 +8,7 @@ permissions: {}
 
 concurrency:
   group: checks-${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.actor == 'renovate[bot]' && false || true }}
 
 jobs:
   enforce-all-checks:


### PR DESCRIPTION
The previous PR (#196) which added `${{ github.action.event }}` to the concurrency group name has not worked. When called, the action event is empty which means the group name is not unique for different events. This results in cancellation of workflow runs for renovate PRs that are synchronizes and edited in quick succession.

There is an open discussion for this issue: https://github.com/orgs/community/discussions/107552

To overcome this I have added a ternary operator that sets `cancel-in-progress` to `false` for the renovate bot.