### PR TITLE
fix(pr-title): Trim the double quotes from the jq output

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -32,7 +32,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          echo "PR_TITLE_LENGTH=$(gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq '.title' | wc -c)" >> "$GITHUB_ENV"
+          {
+            echo 'PR_TITLE_LENGTH<<EOF'
+            $(gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq '.title' | tr -d '"' |wc -c)
+            echo EOF
+          } >> "$GITHUB_ENV"
 
       - name: Add PR comment on failure
         # Only add a comment if the PR title is too long


### PR DESCRIPTION
The double quotes were being in included in the character count. I have used `tr` to remove this prior to the word count.