### PR TITLE
fix(pr-title): Use correct multiline string syntax

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           {
             echo 'PR_TITLE_LENGTH<<EOF'
-            $(gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq '.title' | tr -d '"' |wc -c)
+            gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq '.title' | tr -d '"' |wc -c
             echo EOF
           } >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Multi line commands do not need to use command substitution syntax.